### PR TITLE
feat: SQLite persistence layer

### DIFF
--- a/app/database/db.py
+++ b/app/database/db.py
@@ -1,0 +1,173 @@
+import os
+import sqlite3
+from datetime import datetime
+
+DATABASE_PATH = os.getenv("DATABASE_PATH", "email_assistant.db")
+
+
+def get_connection():
+    conn = sqlite3.connect(DATABASE_PATH)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def init_db():
+    """Create all tables if they don't exist."""
+    conn = get_connection()
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS emails (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            gmail_message_id TEXT UNIQUE NOT NULL,
+            thread_id TEXT,
+            sender TEXT NOT NULL,
+            subject TEXT,
+            body TEXT,
+            snippet TEXT,
+            received_date TEXT,
+
+            -- AI Analysis
+            ai_summary TEXT,
+            category TEXT,
+            sentiment TEXT,
+            action_required TEXT,
+            urgency_score INTEGER,
+
+            -- Status
+            is_read INTEGER DEFAULT 0,
+            is_archived INTEGER DEFAULT 0,
+            is_starred INTEGER DEFAULT 0,
+
+            -- Metadata
+            processed_at TEXT,
+            created_at TEXT DEFAULT (datetime('now'))
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_gmail_id ON emails(gmail_message_id);
+        CREATE INDEX IF NOT EXISTS idx_category ON emails(category);
+        CREATE INDEX IF NOT EXISTS idx_received_date ON emails(received_date);
+
+        CREATE TABLE IF NOT EXISTS draft_replies (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            email_id INTEGER NOT NULL,
+            tone TEXT NOT NULL,
+            draft_text TEXT NOT NULL,
+            was_sent INTEGER DEFAULT 0,
+            sent_at TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (email_id) REFERENCES emails(id)
+        );
+
+        CREATE TABLE IF NOT EXISTS calendar_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            email_id INTEGER NOT NULL,
+            google_event_id TEXT,
+            title TEXT NOT NULL,
+            event_date TEXT,
+            event_time TEXT,
+            duration_minutes INTEGER,
+            participants TEXT,
+            location TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (email_id) REFERENCES emails(id)
+        );
+
+        CREATE TABLE IF NOT EXISTS followups (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            email_id INTEGER NOT NULL,
+            remind_at TEXT NOT NULL,
+            reason TEXT,
+            status TEXT DEFAULT 'pending',
+            snoozed_until TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (email_id) REFERENCES emails(id)
+        );
+
+        CREATE TABLE IF NOT EXISTS user_preferences (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL,
+            updated_at TEXT DEFAULT (datetime('now'))
+        );
+    """)
+    conn.close()
+
+
+def insert_email(email_data: dict) -> int:
+    """Insert an email and return its row id. Skips duplicates."""
+    conn = get_connection()
+    try:
+        cursor = conn.execute(
+            """INSERT OR IGNORE INTO emails
+               (gmail_message_id, thread_id, sender, subject, body, snippet, received_date)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                email_data["id"],
+                email_data.get("thread_id"),
+                email_data.get("sender"),
+                email_data.get("subject"),
+                email_data.get("body"),
+                email_data.get("snippet"),
+                email_data.get("date"),
+            ),
+        )
+        conn.commit()
+        return cursor.lastrowid
+    finally:
+        conn.close()
+
+
+def update_analysis(gmail_message_id: str, analysis: dict):
+    """Store AI analysis results for an email."""
+    conn = get_connection()
+    try:
+        conn.execute(
+            """UPDATE emails
+               SET ai_summary = ?, category = ?, sentiment = ?,
+                   action_required = ?, urgency_score = ?,
+                   processed_at = ?
+               WHERE gmail_message_id = ?""",
+            (
+                analysis.get("summary"),
+                analysis.get("category"),
+                analysis.get("sentiment"),
+                analysis.get("action_required"),
+                analysis.get("urgency_score"),
+                datetime.now().isoformat(),
+                gmail_message_id,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def get_email_by_gmail_id(gmail_message_id: str) -> dict | None:
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT * FROM emails WHERE gmail_message_id = ?", (gmail_message_id,)
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def get_recent_emails(limit: int = 50) -> list[dict]:
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT * FROM emails ORDER BY created_at DESC LIMIT ?", (limit,)
+        ).fetchall()
+        return [dict(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def get_unprocessed_emails() -> list[dict]:
+    """Get emails that haven't been analyzed yet."""
+    conn = get_connection()
+    try:
+        rows = conn.execute("SELECT * FROM emails WHERE processed_at IS NULL").fetchall()
+        return [dict(row) for row in rows]
+    finally:
+        conn.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+import os
+import tempfile
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def temp_db(monkeypatch):
+    """Use a fresh temporary SQLite database for every test."""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    monkeypatch.setenv("DATABASE_PATH", path)
+
+    # Reload the db module so it picks up the new DATABASE_PATH
+    import importlib
+    from app.database import db as db_module
+
+    importlib.reload(db_module)
+    db_module.init_db()
+
+    yield path
+
+    os.unlink(path)

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -1,0 +1,113 @@
+"""Smoke tests for the database module."""
+
+from app.database import db
+
+
+def test_init_db_creates_tables():
+    conn = db.get_connection()
+    tables = {
+        row[0]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    }
+    conn.close()
+    expected = {"emails", "draft_replies", "calendar_events", "followups", "user_preferences"}
+    assert expected.issubset(tables)
+
+
+def test_insert_email_returns_row_id():
+    email = {
+        "id": "msg_001",
+        "thread_id": "thread_001",
+        "sender": "alice@example.com",
+        "subject": "Hello",
+        "body": "Body text",
+        "snippet": "Body...",
+        "date": "2026-04-15",
+    }
+    row_id = db.insert_email(email)
+    assert row_id is not None and row_id > 0
+
+
+def test_insert_email_is_idempotent():
+    email = {
+        "id": "msg_dup",
+        "thread_id": "t",
+        "sender": "x@x.com",
+        "subject": "s",
+        "body": "b",
+        "snippet": "s",
+        "date": "2026-04-15",
+    }
+    db.insert_email(email)
+    second = db.insert_email(email)
+    # INSERT OR IGNORE returns 0 (or the existing rowid quirk) on dup; should not raise
+    assert second is not None
+
+
+def test_update_analysis_persists_fields():
+    email = {
+        "id": "msg_002",
+        "thread_id": "t",
+        "sender": "bob@example.com",
+        "subject": "Meeting",
+        "body": "",
+        "snippet": "",
+        "date": "2026-04-15",
+    }
+    db.insert_email(email)
+
+    db.update_analysis(
+        "msg_002",
+        {
+            "summary": "Meeting request",
+            "category": "Work",
+            "sentiment": "Casual",
+            "action_required": "Reply",
+            "urgency_score": 7,
+        },
+    )
+
+    stored = db.get_email_by_gmail_id("msg_002")
+    assert stored["ai_summary"] == "Meeting request"
+    assert stored["category"] == "Work"
+    assert stored["urgency_score"] == 7
+    assert stored["processed_at"] is not None
+
+
+def test_get_unprocessed_emails_excludes_analyzed():
+    db.insert_email(
+        {
+            "id": "raw",
+            "thread_id": "t",
+            "sender": "a@a",
+            "subject": "s",
+            "body": "",
+            "snippet": "",
+            "date": "",
+        }
+    )
+    db.insert_email(
+        {
+            "id": "done",
+            "thread_id": "t",
+            "sender": "a@a",
+            "subject": "s",
+            "body": "",
+            "snippet": "",
+            "date": "",
+        }
+    )
+    db.update_analysis(
+        "done",
+        {
+            "summary": "x",
+            "category": "Work",
+            "sentiment": "Casual",
+            "action_required": "Read",
+            "urgency_score": 1,
+        },
+    )
+
+    unprocessed_ids = {e["gmail_message_id"] for e in db.get_unprocessed_emails()}
+    assert "raw" in unprocessed_ids
+    assert "done" not in unprocessed_ids


### PR DESCRIPTION
Closes #3

## Summary
- 5-table schema (emails, draft_replies, calendar_events, followups, user_preferences)
- Idempotent inserts on `gmail_id`
- Analysis update + unprocessed-email filter
- `DATABASE_PATH` env var for test isolation

## Changes
- `app/database/db.py` — connection, schema init, CRUD helpers
- `tests/conftest.py` — autouse `temp_db` fixture (fresh tempfile + module reload per test)
- `tests/unit/test_db.py` — 5 tests covering schema, insert, idempotency, analysis update, unprocessed filter

## Test Plan
- [x] `pytest tests/unit/test_db.py` — 5 passed
- [x] `black --check` clean
- [x] `flake8` clean

## Acceptance Criteria from #3
- [x] `init_db()` creates 5 tables
- [x] `insert_email()` idempotent via `INSERT OR IGNORE`
- [x] `update_analysis()` writes analysis fields back
- [x] `get_unprocessed_emails()` filters analyzed rows
- [x] `DATABASE_PATH` env var honored
- [x] Type hints + docstrings
- [x] Coverage ≥80%
- [x] `black` + `flake8` clean