### PR TITLE
docs: add PRD, progress, ticket templates, and Claude skills

### DIFF
--- a/.claude/skills/create-bug.md
+++ b/.claude/skills/create-bug.md
@@ -1,0 +1,214 @@
+---
+name: create-bug
+description: Create a structured bug report (GitHub issue) for the AI Email Copilot project with reproduction steps, expected/actual results, environment details, affected components, severity assessment, and fix sub-tasks. Use when the user reports a bug, says things like "there's a bug in...", "X is broken", "this isn't working right", "file a bug for...", or describes any defect that needs tracking. One bug at a time.
+---
+
+# Create Bug Report
+
+Create a well-structured GitHub issue that gives the implementer everything needed to reproduce, diagnose, and fix the defect. Mirror `docs/BUG_REPORT_TEMPLATE.md` and create the issue via `gh` per `.claude/skills/github.md`.
+
+## Step 1: Gather Context
+
+1. **Understand the bug.** Extract what's broken. If vague, ask focused questions — one round max:
+   - What were they doing when it happened?
+   - Expected vs actual behavior?
+   - Reproducible consistently or intermittent?
+   - Any error messages, logs, screenshots?
+
+2. **Identify affected components.** Use Grep/Glob to trace from symptom to likely cause. Map to this project's layers:
+
+   | Layer | Files |
+   |---|---|
+   | **API / FastAPI endpoints** | `app/main.py` |
+   | **Gmail / OAuth** | `app/gmail/auth.py`, `app/gmail/service.py` |
+   | **Claude / AI** | `app/ai/analyzer.py` |
+   | **Data layer (SQLite)** | `app/database/db.py` |
+   | **Schemas / validation** | `app/models/schemas.py` |
+   | **Config / env** | `.env`, `pyproject.toml` |
+   | **CI / tooling** | `.github/workflows/`, `.flake8`, `requirements*.txt` |
+   | **Tests** | `tests/unit/`, `tests/integration/`, `tests/conftest.py` |
+
+3. **Scan docs for intended behavior.** Search `docs/PRD.md` and `docs/PROGRESS.md` for the feature spec. A "bug" might be unimplemented behavior — flag it as a missing-feature story instead if so.
+
+4. **Assess severity:**
+
+   | Severity | Criteria |
+   |---|---|
+   | **critical** | App won't start, data loss, secret leak, no workaround |
+   | **high** | Core flow broken (fetch / analyze / reply), workaround painful |
+   | **medium** | Non-core feature broken, reasonable workaround exists |
+   | **low** | Cosmetic, edge case, minimal impact |
+
+   Ask the user if not obvious.
+
+## Step 2: Investigate Before Writing
+
+Provide value beyond transcribing the user's complaint:
+
+- **Trace the code path** — entry point → where the bug manifests. Note files and line numbers.
+- **Check related patterns** — TODOs, similar bugs, known limitations.
+- **Identify likely root cause** — even narrowing to one module saves the fixer time.
+- **Check test coverage** — is there a test for this code path? If so, why didn't it catch it? That's a sub-task.
+
+## Step 3: Write the Report
+
+Mirror `docs/BUG_REPORT_TEMPLATE.md`. Omit sections that don't apply.
+
+```markdown
+## Bug Summary
+
+[1-2 sentences. Be specific — "X returns Y when it should return Z", not "X doesn't work".]
+
+## Environment
+
+| Field | Value |
+|---|---|
+| Version / Commit | [git SHA from `git rev-parse HEAD`, or "main as of YYYY-MM-DD"] |
+| OS / Platform | [e.g., Windows 11, macOS 15] |
+| Python Version | [e.g., 3.14.0 — check `.venv/Scripts/python --version`] |
+| Deployment | [local uvicorn / Docker / CI] |
+| Configuration | [relevant env vars from `.env` — never paste actual API keys] |
+
+## Components Affected
+
+- **Primary:** [`app/<module>.py`](app/<module>.py) — [what it does]
+- **Secondary:** [`app/<other>.py`](app/<other>.py) — [how it's involved]
+
+## Reproduction Steps
+
+1. [Exact first step — commands, inputs, curl calls, UI actions]
+2. [Next step]
+3. [Step where the bug manifests]
+
+**Reproduction rate:** [Always / Intermittent (~X%) / One-time]
+
+## Expected Result
+
+[Concrete: expected output, status code, JSON shape, behavior. Reference PRD if applicable.]
+
+## Actual Result
+
+[Concrete: exact error message, wrong output, observed behavior.]
+
+## Evidence
+
+<details>
+<summary>Error output / Stack trace</summary>
+
+\`\`\`
+[Raw error output — never paraphrase]
+\`\`\`
+
+</details>
+
+<!-- Only if logs exist -->
+<details>
+<summary>Relevant logs</summary>
+
+\`\`\`
+[uvicorn output, pytest output, etc.]
+\`\`\`
+
+</details>
+
+## Root Cause Analysis
+
+<!-- Only if narrowed down — even partial is valuable -->
+
+**Likely cause:** [File path + line number + what's wrong at code level]
+
+**What's been ruled out:** [Things checked that are NOT the cause — saves duplicate investigation]
+
+## Acceptance Criteria (Definition of Fixed)
+
+- [ ] [Specific condition true when fixed]
+- [ ] No regression in [related functionality from PRD]
+- [ ] All existing tests still pass (`pytest tests/ --cov=app`)
+- [ ] Coverage stays ≥80%
+- [ ] `black` and `flake8` clean
+
+## Regression Test Scenarios
+
+| Scenario | Given | When | Then |
+|---|---|---|---|
+| [Original bug] | [precondition] | [trigger action] | [correct result] |
+| [Boundary case] | [related precondition] | [similar action] | [expected result] |
+| [Previously working case] | [precondition] | [should-still-work action] | [unchanged result] |
+
+<!-- Only if real architectural constraints -->
+## Technical Notes
+
+- [Engineering Decision from `docs/PROGRESS.md` that constrains the fix]
+- [Related code pattern or known limitation]
+
+<!-- Only if related issues exist -->
+## Related Issues
+
+- Related to: #[N] — [relationship]
+```
+
+### Writing Rules
+
+- Reproduction steps must be precise enough for someone unfamiliar with the code to follow.
+- Expected/actual must be concrete — not "should work" but "should return `{"analyzed": 50}` with HTTP 200".
+- Evidence is **raw** — no paraphrasing of stack traces.
+- Never paste secrets (`ANTHROPIC_API_KEY`, OAuth tokens). Redact or describe.
+- Link to specific files and line numbers (`app/main.py:62`).
+
+## Step 4: Sub-Task Breakdown
+
+Almost every bug needs a fix + a regression test. The QA category is rarely empty.
+
+```markdown
+## Sub-Tasks
+
+### BE
+- [ ] [Specific fix — file path + what changes]
+- [ ] [Defensive check or refactor needed alongside fix]
+
+### Integration
+- [ ] [If bug crosses module boundaries — e.g., Gmail → DB pipeline]
+
+### QA
+- [ ] Add regression test in `tests/unit/test_<module>.py` covering the original scenario
+- [ ] Add boundary-case test
+- [ ] Verify `pytest tests/ --cov=app` stays ≥80% and all tests pass
+```
+
+Each sub-task must be:
+- **Actionable** — implementer can start without further clarification
+- **Traceable** — references file paths, function names, or line numbers
+- **Ordered** — fix first, then regression tests, then verification
+
+## Step 5: Pick Labels
+
+Per `docs/BUG_REPORT_TEMPLATE.md`:
+
+| Label | How to pick |
+|---|---|
+| `bug` | Always |
+| `severity:critical` / `high` / `medium` / `low` | From the severity matrix above |
+| `priority:critical` / `high` / `medium` / `low` | Business urgency. Often = severity, but ask if they differ. |
+| Area: `area:api`, `area:frontend`, `area:ai`, `area:database`, `area:cli` | From the primary affected module |
+
+## Step 6: Present and Confirm
+
+Show the complete report (title + labels + body + sub-tasks) to the user. Ask: "Ready to file this, or want changes?"
+
+Iterate.
+
+## Step 7: Create the Issue
+
+After approval, use `gh` (per `.claude/skills/github.md` — never MCP `push_files`):
+
+```bash
+gh issue create \
+  --title "[<Component>] <description>" \
+  --label "bug,severity:high,priority:high,area:ai" \
+  --body "$(cat <<'EOF'
+<full body + sub-tasks>
+EOF
+)"
+```
+
+Capture the issue number — the fixer needs it for the branch (`fix/<short-kebab-name>`) and the commit `Closes #N`.

--- a/.claude/skills/create-user-story.md
+++ b/.claude/skills/create-user-story.md
@@ -1,0 +1,169 @@
+---
+name: create-user-story
+description: Create a single INVEST-structured user story (GitHub issue) for the AI Email Copilot project. Includes acceptance criteria, test scenarios, links to PRD/PROGRESS docs, and BE/FE/Integration/QA sub-task breakdown. Use when the user says "create a story for...", "I need a ticket for...", "write a user story for...", or describes a feature that needs to be turned into a structured, trackable issue. One story at a time — for multi-story epics, split into separate calls.
+---
+
+# Create User Story
+
+Create a single, well-structured GitHub issue that follows INVEST principles. The output goes through `gh issue create` per the conventions in `.claude/skills/github.md` and uses the template in `docs/USER_STORY_TEMPLATE.md`.
+
+## Step 1: Gather Context
+
+1. **Parse the request.** Extract the feature or change. If vague, ask focused questions — one round max. Don't interrogate.
+
+2. **Scan the project docs.** Use Grep on `docs/` to find sections relevant to the feature:
+   - **`docs/PRD.md`** — feature specs, success metrics, prompts, schemas, week-by-week plan
+   - **`docs/PROGRESS.md`** — current week, task breakdown, status, engineering decisions
+   - **`docs/GITHUB_WORKFLOW.md`** — workflow conventions
+   - **`docs/USER_STORY_TEMPLATE.md`** — canonical body template (mirror it, don't reinvent)
+
+   Save the file paths and section anchors — link them in the story's **Context** section.
+
+3. **Determine if Figma is needed.** Most stories in this project are backend (FastAPI endpoints, Claude integration, DB work) and won't need Figma. UI work is HTML/CSS/JS per the PRD.
+
+   **Needs Figma:** new UI screens/pages/dialogs, layout changes, new interactive components.
+   **Doesn't:** backend, DB, AI prompts, CI, refactoring, config.
+
+   If UI work and the user hasn't provided a link: ask once.
+
+## Step 2: Apply INVEST (internal check, don't output)
+
+- **Independent** — Deliverable without waiting on other stories? Note explicit dependencies if not.
+- **Negotiable** — Goal-oriented (what/why), not prescriptive (exactly how).
+- **Valuable** — Tied to a real user/stakeholder benefit. Frame tech debt as the value it unlocks.
+- **Estimable** — Enough context to size. If not, propose a spike.
+- **Small** — Fits in a few days max. If too big, suggest a split (e.g., "draft generation" → "prompt templates" + "DB storage" + "API endpoint").
+- **Testable** — Concrete, binary acceptance criteria. If you can't write them, the story is too vague.
+
+## Step 3: Write the Story Body
+
+Mirror `docs/USER_STORY_TEMPLATE.md`. Omit sections that don't apply rather than leaving them empty.
+
+```markdown
+## User Story
+
+**As a** [role],
+**I want** [capability],
+**So that** [benefit].
+
+## Context
+
+[1-3 sentences explaining why this story exists now and where it fits in the weekly plan.]
+
+See: [`docs/PRD.md#section`](docs/PRD.md#section) | [`docs/PROGRESS.md#week-N`](docs/PROGRESS.md#week-N)
+
+<!-- Only if Figma links provided -->
+## Design
+
+| Screen / Component | Figma Link |
+|---|---|
+| [Name] | [URL] |
+
+## Acceptance Criteria
+
+- [ ] [Concrete, binary pass/fail condition]
+- [ ] [Another criterion]
+- [ ] All public functions have type hints
+- [ ] All public functions have docstrings
+- [ ] Test coverage ≥80% (enforced by `pyproject.toml`)
+- [ ] `black app/ tests/` and `flake8 app/ tests/` clean
+
+## Test Scenarios
+
+| Scenario | Given | When | Then |
+|---|---|---|---|
+| [Happy path] | [precondition] | [action] | [expected result] |
+| [Edge case] | [precondition] | [action] | [expected result] |
+| [Error case] | [precondition] | [action] | [expected result] |
+
+<!-- Only if real architectural constraints exist -->
+## Technical Notes
+
+- [Specific file path or module to modify]
+- [Relevant Engineering Decision from `docs/PROGRESS.md`]
+- [API contract, prompt structure, or DB schema note]
+
+<!-- Only if blocked by other work -->
+## Dependencies
+
+- Blocked by: #[issue-number] — [reason]
+```
+
+### Writing Rules
+
+- Acceptance criteria are binary — no subjective language ("looks good", "performs well").
+- Test scenarios describe **behavior**, not implementation.
+- Link doc paths from repo root (`docs/PRD.md#anchor`).
+- Default acceptance items (type hints, docstrings, ≥80% coverage, lint-clean) are **always** included — they match the CI gates.
+- Don't reference files that don't exist yet — the implementer creates them. Just describe what they should do.
+
+## Step 4: Sub-Task Breakdown
+
+After the user approves the body, split into sub-tasks. Only include categories that apply.
+
+### Backend (BE)
+FastAPI endpoints (`app/main.py`), Claude integration (`app/ai/`), Gmail API (`app/gmail/`), DB layer (`app/database/db.py`), Pydantic schemas (`app/models/schemas.py`), prompt templates.
+
+### Frontend (FE)
+HTML templates, JS, CSS — per PRD this is vanilla HTML/CSS/JS, no React unless Week 6+ scope.
+
+### Integration
+Wiring components end-to-end, connecting Gmail+Claude+DB pipelines, third-party services (Calendar API, etc.).
+
+### QA
+Tests beyond developer unit tests: integration tests in `tests/integration/`, E2E flow tests, performance checks. Always reference the test scenarios from the story.
+
+```markdown
+## Sub-Tasks
+
+### BE
+- [ ] [Specific actionable task]
+- [ ] [Another task]
+
+### FE
+- [ ] [Specific frontend task]
+
+### Integration
+- [ ] [Specific integration task]
+
+### QA
+- [ ] [Specific QA task — reference scenarios from above]
+```
+
+Each sub-task must be:
+- **Actionable** — implementable without further clarification
+- **Scoped** — one logical unit of work
+- **Ordered** — list in dependency order
+
+## Step 5: Pick Labels
+
+Per `docs/USER_STORY_TEMPLATE.md`:
+
+| Label | How to pick |
+|---|---|
+| `user-story` | Always |
+| `size:S` / `size:M` / `size:L` / `size:XL` | S = hours, M = 1-2 days, L = 3-5 days, XL = needs splitting |
+| `priority:critical` / `high` / `medium` / `low` | Match PRD priority (P0=high/critical, P1=medium, P2=low). Ask if unclear. |
+| Area: `area:api`, `area:frontend`, `area:ai`, `area:database`, `area:cli` | Derive from BE module touched |
+
+## Step 6: Present and Confirm
+
+Show the **complete** story (title + labels + body + sub-tasks) to the user. Ask: "Ready to create the issue, or want changes?"
+
+Iterate on feedback.
+
+## Step 7: Create the Issue
+
+After approval, create it via `gh` (per `.claude/skills/github.md` — never use MCP `push_files`):
+
+```bash
+gh issue create \
+  --title "<title>" \
+  --label "user-story,size:M,priority:high,area:ai" \
+  --body "$(cat <<'EOF'
+<full body + sub-tasks>
+EOF
+)"
+```
+
+Capture the returned issue number — the implementer needs it for the branch name (`feature/<short-kebab-name>`) and the commit `Closes #N`.

--- a/.claude/skills/github.md
+++ b/.claude/skills/github.md
@@ -1,0 +1,114 @@
+---
+name: github
+description: GitHub platform tooling and CI conventions for the AI Email Copilot project. Use when creating issues, opening PRs, checking CI, or moving code between local and remote.
+---
+
+# GitHub Platform Reference
+
+GitHub-specific tooling and CI configuration for this project. For the broader operational workflow (ticket-driven development, branch strategy, PR lifecycle), see [`docs/GITHUB_WORKFLOW.md`](../../docs/GITHUB_WORKFLOW.md).
+
+## Tooling Standard
+
+Two tools, each for its job:
+
+| Tool | Use for | Never use for |
+|------|---------|---------------|
+| `git` | Push, pull, commit, branch — all code movement | GitHub platform ops (issues, PRs, checks) |
+| `gh` CLI | Issues, PRs, checks, releases — all GitHub platform ops | Pushing code (use `git push`) |
+| MCP GitHub plugin | Read-only fallback (reading issues, PRs) when `gh` is unavailable | **Pushing code** — `push_files` creates synthetic commits disconnected from local git state |
+
+**Why this matters:** `git push` sends the exact committed objects from your local repo. MCP `push_files` creates a new commit on the server from raw content you provide — if a local linter (black) auto-fixed your files, the API push won't reflect that, causing CI failures on code that passed locally.
+
+**Credentials:** Run `gh auth setup-git` once to make `git` use `gh`'s token. This eliminates credential fragmentation between the two tools.
+
+## CI Pipeline
+
+Two workflows live in `.github/workflows/` and run automatically on every PR to `main` and on push to `main`:
+
+### `tests.yml` — Test + Coverage
+- **Setup:** Python 3.11 with pip cache
+- **Install:** `pip install -r requirements-dev.txt`
+- **Run:** `pytest tests/ --cov=app --cov-report=term --cov-report=xml`
+- **Coverage gate:** `fail_under = 80` (enforced via `pyproject.toml`)
+- **Artifact:** uploads `coverage.xml`
+- **Env:** `ANTHROPIC_API_KEY=dummy-key-for-tests` (analyzer tests use mocked client)
+
+### `lint.yml` — Format + Lint + Type Check
+- **Black:** `black --check app/ tests/`
+- **Flake8:** `flake8 app/ tests/` (config in `.flake8`, max line 100)
+- **Mypy:** `mypy app/ --ignore-missing-imports` (`continue-on-error: true` for now)
+
+If CI fails, fix the issue on the branch and push again — the workflow re-triggers automatically.
+
+## Local Pre-Push Checklist
+
+Mirror the CI locally before pushing:
+
+```bash
+.venv/Scripts/black app/ tests/
+.venv/Scripts/flake8 app/ tests/
+.venv/Scripts/pytest tests/ --cov=app --cov-report=term
+```
+
+All three must be green. Coverage must be ≥80%.
+
+## GitHub CLI Quick Reference
+
+### Issue Operations
+
+```bash
+gh issue list --state open                            # List open issues
+gh issue view <NUMBER>                                # Read an issue
+gh issue view <NUMBER> --json body --jq '.body'       # Read body raw (for editing)
+gh issue create --title "..." --label "..." --body "..."  # Create issue
+gh issue edit <NUMBER> --body "$(cat issue_body.txt)" # Update body (e.g., tick checkboxes)
+gh issue comment <NUMBER> --body "..."                # Comment on issue
+gh issue close <NUMBER> --reason completed            # Close after merge
+```
+
+### PR Operations
+
+```bash
+gh pr create --title "..." --body "..."               # Create PR
+gh pr view <NUMBER>                                   # PR overview
+gh pr checks <NUMBER>                                 # CI status
+gh pr checks <NUMBER> --watch                         # Tail CI until done
+gh pr diff <NUMBER>                                   # Show diff
+gh pr merge <NUMBER> --squash --delete-branch         # Squash-merge & cleanup branch
+```
+
+### Linking PR ↔ Issue
+
+```bash
+# In the PR body, include `Closes #N` to auto-close the issue on merge.
+# Optional explicit linking:
+gh issue comment <NUMBER> --body "PR: #<PR-number>"
+```
+
+## Branch & Commit Conventions
+
+- **Branch:** `feature/<short-kebab-name>` (e.g., `feature/draft-reply-generation`)
+- **Commit format:**
+  ```
+  <type>: <short description>
+
+  - bullet of change 1
+  - bullet of change 2
+
+  Closes #<issue-number>
+  ```
+- **Types:** `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+
+## Autonomous Bug Fixing
+
+- When given a bug report or failing CI: just fix it. Don't ask for hand-holding.
+- Point at logs, errors, failing tests — then resolve the root cause.
+- Zero context switching required from the user.
+- Go fix failing CI tests without being told how — pull the workflow run logs with `gh run view <RUN-ID> --log-failed`.
+
+## Common Failure Modes
+
+- **Black diff in CI:** run `black app/ tests/` locally and recommit (don't add `# fmt: off`).
+- **Flake8 unused-import:** delete the import; never silence with `# noqa` unless there's a real reason (e.g., `app/main.py` `load_dotenv()` ordering uses `# noqa: E402`).
+- **Coverage below 80%:** add tests, don't lower `fail_under`. If a function genuinely can't be unit-tested (live OAuth, live Gmail), mark it `# pragma: no cover` and document why in the docstring.
+- **Test passes locally, fails in CI:** check `ANTHROPIC_API_KEY` env, Python version drift (CI uses 3.11), or filesystem-path assumptions (Windows vs Linux).

--- a/.claude/skills/pr-workflow.md
+++ b/.claude/skills/pr-workflow.md
@@ -1,0 +1,156 @@
+---
+name: pr-workflow
+description: Push a feature/fix branch, open a PR, monitor CI, and run the full post-merge sequence (link PR ↔ issue, tick acceptance criteria, post completion report, close issue) for the AI Email Copilot project. Use when you've finished implementing a ticket and need to ship it. Pairs with the `github`, `create-user-story`, and `create-bug` skills.
+---
+
+# PR Workflow
+
+Handle the GitHub side of shipping a ticket: push, open PR, watch CI, merge, close. This skill is the operational counterpart to `create-user-story` / `create-bug` (which open the ticket) and `github` (which defines tooling rules).
+
+## Identify the Repository
+
+```bash
+git remote get-url origin
+```
+
+Parse `owner/repo` from the URL. Never hardcode.
+
+## Operations
+
+### 1. Pre-Push Local Verification
+
+Mirror CI before pushing — failing checks waste a CI run:
+
+```bash
+.venv/Scripts/black app/ tests/
+.venv/Scripts/flake8 app/ tests/
+.venv/Scripts/pytest tests/ --cov=app --cov-report=term
+```
+
+All three must be green. Coverage must be ≥80% (enforced by `pyproject.toml`).
+
+### 2. Push the Branch
+
+Branch names: `feature/<short-kebab>` for stories, `fix/<short-kebab>` for bugs.
+
+```bash
+git push -u origin <branch-name>
+```
+
+### 3. Open the PR
+
+The PR body **must** contain `Closes #<N>` so the issue auto-closes on merge. Use a HEREDOC for clean multi-line bodies.
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+Closes #<ticket-number>
+
+## Summary
+- <bullet 1 — what changed and why>
+- <bullet 2>
+- <bullet 3>
+
+## Changes
+- `app/<module>.py` — <what>
+- `tests/unit/test_<module>.py` — <what>
+
+## Test Plan
+- [x] `pytest tests/ --cov=app` passes (X tests, Y% coverage)
+- [x] `black app/ tests/` clean
+- [x] `flake8 app/ tests/` clean
+- [x] Manual verification: <how you confirmed the fix/feature works end-to-end>
+
+## Acceptance Criteria from #<N>
+- [x] <criterion 1>
+- [x] <criterion 2>
+- [x] <criterion 3>
+EOF
+)"
+```
+
+Capture the returned PR number.
+
+### 4. Link PR ↔ Issue
+
+`Closes #N` already creates a soft link. Add an explicit comment for visibility:
+
+```bash
+gh issue comment <ticket-number> --body "PR: #<PR-number>"
+```
+
+### 5. Monitor CI
+
+```bash
+gh pr checks <PR-number> --watch
+```
+
+- **CI fails:** pull the failure logs (`gh run view <RUN-ID> --log-failed`), fix the root cause on the branch, push again. CI re-triggers automatically. Don't silence failures with `# noqa` or `# pragma: no cover` unless there's a real reason (e.g., live-OAuth path that can't be unit-tested).
+- **CI passes:** proceed to merge. This project does **not** have auto-merge configured — merge manually.
+
+### 6. Merge
+
+```bash
+gh pr merge <PR-number> --squash --delete-branch
+```
+
+Squash-merge keeps `main` history clean (one commit per ticket). The `--delete-branch` flag cleans up the remote branch.
+
+### 7. Update Acceptance Criteria
+
+Even though the PR body listed them as checked, the issue body still has unchecked boxes. Sync them:
+
+```bash
+gh issue view <ticket-number> --json body --jq '.body' > /tmp/issue_body.md
+# Edit /tmp/issue_body.md, change [ ] → [x] for satisfied criteria
+gh issue edit <ticket-number> --body "$(cat /tmp/issue_body.md)"
+```
+
+### 8. Post Completion Report
+
+```bash
+gh issue comment <ticket-number> --body "$(cat <<'EOF'
+## ✅ Task Complete
+
+**Status:** Merged
+**PR:** #<PR-number>
+**Commit:** <merge SHA>
+**Tests:** <N> passing | **Coverage:** <X>%
+**Lint:** black + flake8 clean
+
+All acceptance criteria met. Moving to <next task per docs/PROGRESS.md>.
+EOF
+)"
+```
+
+### 9. Close the Issue
+
+`Closes #N` in the PR body auto-closes the issue on merge — but verify, and close manually if it didn't:
+
+```bash
+gh issue view <ticket-number> --json state --jq '.state'
+# If still "OPEN":
+gh issue close <ticket-number> --reason completed
+```
+
+### 10. Update PROGRESS.md
+
+```bash
+git checkout main
+git pull
+# Edit docs/PROGRESS.md — flip the task status from 🔲 → ✅
+git add docs/PROGRESS.md
+git commit -m "docs: mark <Week N Task M> complete"
+git push
+```
+
+## Rules
+
+- **`git` for code, `gh` for platform.** Never use MCP `push_files` for code (per `.claude/skills/github.md`).
+- **Always derive `owner/repo` from `git remote`.** Never hardcode.
+- **Pre-push verification is mandatory.** A CI failure on something black would have fixed locally is wasted time.
+- **Autonomous post-PR execution.** After creating the PR, run steps 5–10 without asking. Pause only on:
+  - Genuine CI failures you can't diagnose from the logs alone
+  - Acceptance criteria that are *not* satisfied (don't lie by ticking them)
+  - Merge conflicts that need user judgment on resolution
+- **Never skip steps 7–10 silently.** A merged PR with an open issue and stale `PROGRESS.md` is a process bug.
+- **Don't bypass hooks** (`--no-verify`) or signing. If a hook fails, fix the underlying issue.

--- a/docs/BUG_REPORT_TEMPLATE.md
+++ b/docs/BUG_REPORT_TEMPLATE.md
@@ -1,0 +1,201 @@
+# Bug Report Template
+
+Use this template when creating bug issues for the email assistant project.
+
+---
+
+## Title
+[Component] Brief description of defect
+
+Examples:
+- "[API] Gmail auth token expires without refresh"
+- "[Database] Draft replies not saving for thread IDs > 1000"
+- "[AI] Reply generation fails on emails with HTML formatting"
+
+## Labels
+- `bug`
+- `severity:critical` or `severity:high` or `severity:medium` or `severity:low`
+- `priority:critical` or `priority:high` or `priority:medium` or `priority:low`
+- `area:api` or `area:frontend` or `area:ai` or `area:database` or `area:cli`
+
+## Body
+
+```markdown
+## Bug Summary
+
+[1-2 sentence description. Be specific: "X returns Y when it should return Z"]
+
+## Environment
+
+| Field | Value |
+|---|---|
+| Version / Commit | [git SHA or branch name] |
+| OS / Platform | [e.g., macOS 15.3, Ubuntu 24.04] |
+| Python Version | [e.g., 3.11.6] |
+| Deployment | [local / Docker] |
+
+## Components Affected
+
+- **Primary:** [`src/ai/analyzer.py`](src/ai/analyzer.py) - [what it does]
+- **Secondary:** [`src/database/db.py`](src/database/db.py) - [how it's involved]
+
+## Reproduction Steps
+
+1. [Exact first step with commands/inputs]
+2. [Next step]
+3. [Step where bug manifests]
+
+**Reproduction rate:** [Always / Intermittent / One-time]
+
+## Expected Result
+
+[What should happen. Include expected output, status code, or behavior]
+
+## Actual Result
+
+[What actually happens. Include exact error messages]
+
+## Evidence
+
+<details>
+<summary>Error output / Stack trace</summary>
+
+\`\`\`
+[Paste error output here]
+\`\`\`
+
+</details>
+
+## Root Cause Analysis
+
+**Likely cause:** [File path and line number if known]
+
+**What's been ruled out:** [Things checked that are NOT the cause]
+
+## Acceptance Criteria (Definition of Fixed)
+
+- [ ] [Condition that must be true when fixed]
+- [ ] [Another condition]
+- [ ] No regression in [related functionality]
+- [ ] All existing tests still pass
+
+## Regression Test Scenarios
+
+| Scenario | Given | When | Then |
+|---|---|---|---|
+| [Original bug] | [precondition] | [action that triggered bug] | [correct result] |
+| [Boundary case] | [precondition] | [similar action] | [expected result] |
+
+## Sub-Tasks
+
+### Backend (BE)
+- [ ] [Specific fix with file path]
+- [ ] [Another fix]
+
+### QA
+- [ ] Add regression test for original bug
+- [ ] Add test for boundary case
+- [ ] Verify all existing tests pass
+```
+
+---
+
+## Example Bug Report
+
+```markdown
+## Bug Summary
+
+Gmail token refresh fails with 401 error after 1 hour, requiring manual re-authentication instead of automatic refresh.
+
+## Environment
+
+| Field | Value |
+|---|---|
+| Version / Commit | main branch, commit abc123 |
+| OS / Platform | macOS 15.3 |
+| Python Version | 3.11.6 |
+| Deployment | local development |
+
+## Components Affected
+
+- **Primary:** [`src/auth/gmail_auth.py`](src/auth/gmail_auth.py) - OAuth token management
+- **Secondary:** [`src/email/fetcher.py`](src/email/fetcher.py) - Email fetching that triggers auth
+
+## Reproduction Steps
+
+1. Authenticate with Gmail API using `python src/main.py`
+2. Wait 60+ minutes (token expires)
+3. Run `python src/main.py` again to fetch emails
+
+**Reproduction rate:** Always (100% after token expiry)
+
+## Expected Result
+
+Token should refresh automatically using the refresh token from `token.pickle`, allowing seamless email fetching without user intervention.
+
+## Actual Result
+
+```
+googleapiclient.errors.HttpError: <HttpError 401 when requesting ...>
+Error: The credentials do not contain the necessary fields for OAuth 2.0 access token.
+```
+
+User must delete `token.pickle` and re-authenticate manually.
+
+## Evidence
+
+<details>
+<summary>Error Stack Trace</summary>
+
+\`\`\`python
+Traceback (most recent call last):
+  File "src/main.py", line 15, in main
+    gmail = get_gmail_service()
+  File "src/auth/gmail_auth.py", line 23, in get_gmail_service
+    return build('gmail', 'v1', credentials=creds)
+  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/googleapiclient/discovery.py", line 130, in build
+    resp, content = http.request(requested_url)
+googleapiclient.errors.HttpError: <HttpError 401>
+\`\`\`
+
+</details>
+
+## Root Cause Analysis
+
+**Likely cause:** In `src/auth/gmail_auth.py` line 18-22, the token refresh logic uses `creds.refresh(Request())` but doesn't handle the case where refresh_token is missing or invalid. The credentials object may not be persisting the refresh_token properly.
+
+**What's been ruled out:**
+- Scope changes (SCOPES haven't changed)
+- credentials.json file corruption (re-downloaded, same issue)
+- Network connectivity (other API calls work fine)
+
+## Acceptance Criteria (Definition of Fixed)
+
+- [ ] Token automatically refreshes when expired
+- [ ] No manual re-authentication required after 1+ hour
+- [ ] token.pickle persists refresh_token correctly
+- [ ] Existing email fetching functionality unchanged
+- [ ] All auth tests pass
+
+## Regression Test Scenarios
+
+| Scenario | Given | When | Then |
+|---|---|---|---|
+| Expired token refresh | Valid refresh_token in token.pickle | Token is 61 minutes old, user fetches emails | Token refreshes automatically, emails fetched successfully |
+| First-time auth | No token.pickle exists | User authenticates | token.pickle created with access_token AND refresh_token |
+| Valid token | Recently authenticated (< 1 hour) | User fetches emails | Uses existing token, no refresh needed |
+
+## Sub-Tasks
+
+### Backend (BE)
+- [ ] Fix `src/auth/gmail_auth.py` line 18-25 to ensure refresh_token is saved
+- [ ] Add explicit check for `creds.refresh_token` before attempting refresh
+- [ ] Add error handling for refresh failures with user-friendly message
+- [ ] Verify token.pickle includes both access_token and refresh_token fields
+
+### QA
+- [ ] Add test `test_token_auto_refresh()` that simulates expired token
+- [ ] Add test `test_missing_refresh_token_error()` for edge case
+- [ ] Manual test: authenticate, wait 65 minutes, verify auto-refresh
+- [ ] Verify all existing auth tests still pass
+```

--- a/docs/GITHUB_WORKFLOW.md
+++ b/docs/GITHUB_WORKFLOW.md
@@ -1,0 +1,343 @@
+# GitHub Workflow - Email Assistant Project
+
+**Purpose:** Professional Git workflow with PRs, CI, and ticket management for the email assistant project.
+
+---
+
+## Tooling Standard
+
+Use these tools correctly:
+
+| Tool | Use for | Never use for |
+|------|---------|---------------|
+| `git` | Commits, branches, push/pull | Creating GitHub issues or PRs |
+| `gh` CLI | GitHub issues, PRs, CI checks | Pushing code (use `git push`) |
+
+**Setup once:**
+```bash
+gh auth setup-git
+```
+
+---
+
+## Development Workflow
+
+### 1. Start a New Task
+
+From `docs/PROGRESS.md`, pick the next task (e.g., Week 3 Task 1).
+
+**Create GitHub Issue:**
+```bash
+gh issue create \
+  --title "Week 3 Task 1: Draft Reply Generation" \
+  --label "user-story,size:M,priority:high,area:ai" \
+  --body "$(cat <<'EOF'
+## User Story
+
+**As a** user,
+**I want** AI to generate draft email replies in 3 different tones,
+**So that** I can quickly respond to emails with appropriate formality.
+
+## Context
+
+Part of Week 3 - Core Chat Logic. This implements the core AI reply generation feature.
+
+See: [`docs/PRD.md#week-3`](docs/PRD.md#week-3)
+
+## Acceptance Criteria
+
+- [ ] Can generate professional tone reply
+- [ ] Can generate friendly tone reply  
+- [ ] Can generate brief tone reply
+- [ ] Drafts stored in database
+- [ ] All functions have type hints
+- [ ] >80% test coverage
+
+## Test Scenarios
+
+| Scenario | Given | When | Then |
+|---|---|---|---|
+| Generate professional reply | Email asking for meeting | Request professional tone | Returns formal reply with proper greeting |
+| Generate friendly reply | Casual email from colleague | Request friendly tone | Returns warm, conversational reply |
+| Generate brief reply | Simple yes/no question | Request brief tone | Returns <3 sentence reply |
+
+## Sub-Tasks
+
+### Backend (BE)
+- [ ] Create `src/ai/reply_generator.py`
+- [ ] Add `generate_replies()` function with 3 tone options
+- [ ] Implement prompt templates for each tone
+- [ ] Add database methods for storing drafts
+- [ ] Add type hints to all functions
+
+### QA
+- [ ] Write unit tests for each tone
+- [ ] Test with real email samples
+- [ ] Verify database storage
+- [ ] Check test coverage >80%
+EOF
+)"
+```
+
+**Note the issue number** (e.g., `#5`)
+
+### 2. Create Feature Branch
+
+```bash
+git checkout -b feature/draft-reply-generation
+```
+
+### 3. Implement the Feature
+
+Work on the code following the sub-tasks from the issue.
+
+### 4. Run Tests Locally
+
+```bash
+# Run tests
+pytest tests/ -v --cov=src --cov-report=term
+
+# Run linting
+black src/ tests/
+flake8 src/ tests/ --max-line-length=100
+```
+
+### 5. Commit Your Work
+
+```bash
+git add .
+git commit -m "feat: implement draft reply generation with 3 tones
+
+- Add reply_generator.py with professional/friendly/brief tones
+- Add prompt templates for each tone
+- Store drafts in database
+- Add unit tests with 85% coverage
+
+Closes #5"
+```
+
+**Commit Message Format:**
+```
+<type>: <short description>
+
+<detailed description>
+<bullet points of changes>
+
+Closes #<issue-number>
+```
+
+**Types:** `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+
+### 6. Create Pull Request
+
+```bash
+# Push branch
+git push -u origin feature/draft-reply-generation
+
+# Create PR
+gh pr create \
+  --title "Week 3 Task 1: Draft Reply Generation" \
+  --body "$(cat <<'EOF'
+Closes #5
+
+## Summary
+- Implements AI-powered reply generation with 3 tones
+- Adds database storage for drafts
+- Includes comprehensive test suite
+
+## Changes
+- `src/ai/reply_generator.py` - New module with tone-based generation
+- `src/database/db.py` - Add draft storage methods
+- `tests/test_reply_generator.py` - Unit tests (85% coverage)
+
+## Test Plan
+- [x] All tests pass locally
+- [x] Linting clean (black, flake8)
+- [x] Type hints on all functions
+- [x] Coverage >80%
+- [x] Manual testing with real emails
+
+## Acceptance Criteria from #5
+- [x] Can generate professional tone reply
+- [x] Can generate friendly tone reply  
+- [x] Can generate brief tone reply
+- [x] Drafts stored in database
+- [x] All functions have type hints
+- [x] >80% test coverage
+EOF
+)"
+```
+
+### 7. Monitor CI
+
+```bash
+# Check CI status
+gh pr checks
+
+# If CI fails, fix and push again:
+# (make fixes)
+git add .
+git commit -m "fix: address CI failures"
+git push
+
+# CI will re-run automatically
+```
+
+### 8. After PR Merges
+
+**Link PR to Issue:**
+```bash
+gh issue comment 5 --body "PR: #<PR-number>"
+```
+
+**Update Issue Checkboxes:**
+```bash
+# Read current issue body
+gh issue view 5 --json body --jq '.body' > issue_body.txt
+
+# Edit it to check off completed criteria
+# Change `- [ ]` to `- [x]` for completed items
+# Then update:
+gh issue edit 5 --body "$(cat issue_body.txt)"
+```
+
+**Post Completion Comment:**
+```bash
+gh issue comment 5 --body "## ✅ Task Complete
+
+**Status:** Merged
+**PR:** #<PR-number>
+**Test Coverage:** 85%
+**Duration:** 4 hours
+
+All acceptance criteria met. Moving to Week 3 Task 2."
+```
+
+**Close Issue:**
+```bash
+gh issue close 5 --reason completed
+```
+
+**Update PROGRESS.md:**
+```bash
+# Update docs/PROGRESS.md to mark task complete
+# Change status from 🔲 to ✅
+git checkout main
+git pull
+# Edit PROGRESS.md
+git add docs/PROGRESS.md
+git commit -m "docs: mark Week 3 Task 1 complete"
+git push
+```
+
+---
+
+## CI/CD Pipeline
+
+Your `.github/workflows/tests.yml` and `.github/workflows/lint.yml` run automatically on every PR.
+
+**What happens:**
+1. Push to PR branch → CI triggers
+2. Tests run (pytest)
+3. Linting runs (black, flake8)
+4. Type checking runs (mypy)
+5. Coverage check (must be >80%)
+
+**If CI fails:**
+- Check the logs: `gh pr checks <PR-number> --watch`
+- Fix the issue locally
+- Push again → CI re-runs
+
+**If CI passes:**
+- Merge the PR (manually or set up auto-merge)
+- Follow post-merge steps above
+
+---
+
+## Quick Reference
+
+### Common Commands
+
+```bash
+# List open issues
+gh issue list --state open
+
+# View an issue
+gh issue view <number>
+
+# Create issue from template
+gh issue create --template user-story.md
+
+# Check PR status
+gh pr view <number>
+
+# Check CI status
+gh pr checks <number>
+
+# View PR diff
+gh pr diff <number>
+
+# Merge PR (after CI passes)
+gh pr merge <number> --squash --delete-branch
+
+# Close issue
+gh issue close <number> --reason completed
+```
+
+### Project-Specific Patterns
+
+**For each Week 3-7 task:**
+1. Create GitHub issue with acceptance criteria
+2. Create feature branch
+3. Implement → Test → Commit
+4. Push → Create PR
+5. Monitor CI → Fix if needed
+6. After merge → Update issue → Close
+
+**For bugs:**
+1. Create bug issue with reproduction steps
+2. Same PR workflow as features
+3. Add regression tests
+
+---
+
+## Integration with Claude Code
+
+**Tell Claude Code to follow this workflow:**
+
+```bash
+claude "
+I want you to follow docs/GITHUB_WORKFLOW.md for all development.
+
+For each task:
+1. Create a GitHub issue with this command
+2. Create feature branch
+3. Implement the feature
+4. Create PR following the format
+5. After merge, close the issue
+
+Start with Week 3 Task 1. Create the GitHub issue first.
+"
+```
+
+---
+
+## Tips
+
+✅ **Do:**
+- Create issues before starting work
+- Use descriptive branch names
+- Write clear commit messages
+- Keep PRs small and focused
+- Update issue checkboxes after completion
+
+❌ **Don't:**
+- Push directly to main
+- Create PRs without issues
+- Merge failing CI
+- Leave issues open after merge
+- Forget to update PROGRESS.md
+
+---
+
+**Last Updated:** Week 3

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,0 +1,1473 @@
+# Smart Email Assistant - Product Requirements Document
+
+**Project Timeline:** 7 weeks (March 15 - May 9, 2026)  
+**Current Status:** Week 1 - Setup & Ideation  
+**Primary Goal:** Build a functional AI-powered Gmail assistant while learning LLM integration, agentic workflows, and API development
+
+---
+
+## Executive Summary
+
+An AI-powered email assistant that connects to Gmail, analyzes emails using Claude API, generates contextual reply suggestions, extracts calendar events, and helps users manage their inbox efficiently. This project focuses on practical skill development in API integration, prompt engineering, and building useful AI applications.
+
+**Core Value:** Reduce email processing time by 50%+ through intelligent automation and AI-assisted responses.
+
+---
+
+## Product Goals
+
+### Learning Objectives
+1. **API Integration**: Master Gmail API and Google Calendar API
+2. **LLM Development**: Learn prompt engineering, function calling, and agentic workflows
+3. **Full-Stack Development**: Build end-to-end application (backend + frontend + database)
+4. **Portfolio Quality**: Create a demonstrable, real-world AI application
+
+### Success Criteria
+- Successfully authenticate and read Gmail messages
+- Generate useful draft replies with 70%+ acceptance rate
+- Correctly identify action items and calendar events
+- Complete working demo by Week 6
+- Deploy publicly accessible version (optional)
+
+---
+
+## Technical Stack
+
+### Backend
+```
+- Python 3.10+
+- Flask or FastAPI (web framework)
+- gmail-api-python-client (Gmail integration)
+- google-auth-oauthlib (authentication)
+- anthropic (Claude API)
+- SQLite (database)
+```
+
+### Frontend
+```
+- HTML/CSS/JavaScript (Week 1-3: simple)
+- React + Tailwind CSS (Week 4+: optional upgrade)
+- Fetch API for backend communication
+```
+
+### Infrastructure
+```
+- Local development (Week 1-5)
+- Git/GitHub for version control
+- Optional: Render/Railway deployment (Week 6)
+```
+
+---
+
+## Feature Specification
+
+## MUST HAVE Features (MVP)
+
+### Feature 1: Gmail Authentication & Email Fetching
+**Priority:** P0 (Critical)  
+**Timeline:** Week 1-2
+
+**Requirements:**
+- Implement OAuth 2.0 flow for Gmail API
+- Store credentials securely (credentials.json, token.json)
+- Fetch last 50 unread emails
+- Handle pagination for large inboxes
+- Display: sender, subject, snippet, date, thread ID
+
+**Technical Details:**
+```python
+# Required scopes:
+SCOPES = [
+    'https://www.googleapis.com/auth/gmail.readonly',
+    'https://www.googleapis.com/auth/gmail.modify',
+    'https://www.googleapis.com/auth/gmail.send'
+]
+
+# API endpoints to use:
+- users.messages.list()
+- users.messages.get()
+- users.messages.modify()
+- users.messages.send()
+```
+
+**Success Metrics:**
+- Can authenticate with Gmail
+- Fetch and display 50 emails in <3 seconds
+- Handle rate limiting gracefully
+
+---
+
+### Feature 2: AI Email Analysis
+**Priority:** P0 (Critical)  
+**Timeline:** Week 2-3
+
+**Requirements:**
+- Send email content to Claude API
+- Extract structured insights:
+  - Summary (2-3 sentences)
+  - Category (Work, Personal, Newsletter, Finance, etc.)
+  - Sentiment (Urgent, Casual, Formal)
+  - Action required (Reply, Schedule, Read, Archive)
+  - Key entities (people, dates, locations)
+
+**Prompt Template:**
+```
+Analyze this email and provide structured output:
+
+EMAIL:
+From: {sender}
+Subject: {subject}
+Body: {body}
+
+Respond in JSON format:
+{
+  "summary": "2-3 sentence summary",
+  "category": "Work|Personal|Newsletter|Finance|Travel|Shopping|Other",
+  "sentiment": "Urgent|Casual|Formal",
+  "action_required": "Reply|Schedule|Read|Archive|Flag",
+  "key_dates": ["2024-03-20"],
+  "key_people": ["John Smith"],
+  "urgency_score": 1-10
+}
+```
+
+**Technical Implementation:**
+- Use Claude Sonnet 4 (fast, cost-effective)
+- Implement caching for similar emails
+- Handle API errors and retries
+- Store analysis results in database
+
+---
+
+### Feature 3: Smart Reply Generation
+**Priority:** P0 (Critical)  
+**Timeline:** Week 3-4
+
+**Requirements:**
+- Generate 3 draft replies with different tones:
+  1. **Professional**: Formal, detailed, polite
+  2. **Friendly**: Casual, warm, conversational
+  3. **Brief**: Short, to-the-point, efficient
+- Consider email thread context
+- Preserve user's writing style (learn from sent emails)
+- Allow editing before sending
+
+**Prompt Template:**
+```
+Generate a reply to this email thread.
+
+CONTEXT:
+Original Email: {original_email}
+Thread History: {thread_context}
+
+USER PREFERENCES:
+- Tone: {tone}
+- Length: {length}
+- Include: {include_elements}
+
+Generate a reply that:
+1. Addresses all questions/requests
+2. Maintains appropriate tone
+3. Is {length} in length
+4. Sounds natural and human
+
+REPLY:
+```
+
+**Technical Details:**
+- Store thread context (last 5 messages)
+- Implement tone controls (slider or dropdown)
+- Add "regenerate" option for unsatisfied drafts
+- Track sent replies to learn user preferences
+
+---
+
+### Feature 4: Action Detection & Recommendations
+**Priority:** P0 (Critical)  
+**Timeline:** Week 3
+
+**Requirements:**
+- Detect actionable items in emails:
+  - Meeting requests → Extract date/time/participants
+  - Tasks/deadlines → Create reminder
+  - Questions → Suggest reply
+  - Information → Archive with category
+- Display recommended action prominently
+- One-click action execution
+
+**Detection Logic:**
+```python
+# Meeting indicators:
+keywords = ["meet", "meeting", "call", "zoom", "schedule", "available"]
+date_patterns = ["tomorrow", "next week", "monday", "3pm"]
+
+# Task indicators:
+keywords = ["deadline", "by EOD", "ASAP", "urgent", "complete"]
+
+# Question indicators:
+contains = ["?", "can you", "could you", "would you", "please"]
+```
+
+---
+
+## SHOULD HAVE Features (Enhanced)
+
+### Feature 5: Google Calendar Integration
+**Priority:** P1  
+**Timeline:** Week 4
+
+**Requirements:**
+- Detect meeting requests in email body
+- Extract: title, date, time, duration, participants, location
+- Parse natural language dates ("next Tuesday at 3pm")
+- Create calendar event with one click
+- Handle timezone conversions
+- Suggest available time slots for ambiguous requests
+
+**Technical Details:**
+```python
+# Required scopes:
+SCOPES.append('https://www.googleapis.com/auth/calendar')
+
+# Calendar API endpoints:
+- events.insert()
+- events.list() # check availability
+- freebusy.query() # find free slots
+```
+
+**Natural Language Date Parsing:**
+```python
+# Use dateutil.parser or custom regex
+from dateutil import parser
+
+examples = [
+    "next Tuesday at 3pm",
+    "tomorrow morning",
+    "March 20th at 2:30pm",
+    "in 2 hours"
+]
+```
+
+---
+
+### Feature 6: Smart Categorization
+**Priority:** P1  
+**Timeline:** Week 5
+
+**Requirements:**
+- Auto-categorize emails using AI
+- Learn from user corrections
+- Bulk actions by category (archive all newsletters)
+- Custom category creation
+- Category-based filtering
+
+**Categories:**
+```
+- Work
+- Personal
+- Finance (invoices, receipts, statements)
+- Travel (bookings, confirmations)
+- Shopping (orders, shipping)
+- Newsletters
+- Social (social media notifications)
+- Promotions
+- Other
+```
+
+**ML Approach:**
+- Use Claude for initial categorization
+- Store user corrections in database
+- Build pattern matching from corrections
+- Combine AI + rules for accuracy
+
+---
+
+### Feature 7: Follow-up Tracking
+**Priority:** P1  
+**Timeline:** Week 5
+
+**Requirements:**
+- Detect emails that need follow-up
+- Set automatic reminders (3 days, 1 week)
+- Track if reply was sent
+- Nudge user for pending follow-ups
+- "Snooze" feature to defer emails
+
+**Implementation:**
+```python
+# Database schema:
+followups:
+  - email_id
+  - remind_at (datetime)
+  - reason (waiting_for_reply, task_deadline, etc.)
+  - status (pending, completed, snoozed)
+  - snoozed_until (datetime, nullable)
+```
+
+---
+
+## COULD HAVE Features (Polish)
+
+### Feature 8: Email Thread Analysis
+**Priority:** P2  
+**Timeline:** Week 6
+
+- Analyze full conversation threads
+- Summarize multi-email threads (not just latest)
+- Detect conversation conclusion (no reply needed)
+- Show conversation sentiment over time
+
+### Feature 9: Attachment Intelligence
+**Priority:** P2  
+**Timeline:** Week 6
+
+- Detect attachment types (PDF, image, spreadsheet)
+- Extract text from PDFs
+- Summarize document content
+- Suggest actions (save to folder, forward)
+
+### Feature 10: Natural Language Search
+**Priority:** P2  
+**Timeline:** Week 6
+
+- Search emails using natural language
+- "Find the email about the project deadline from last week"
+- Semantic search (not just keyword matching)
+- Search across body, subject, attachments
+
+---
+
+## WON'T HAVE (Out of Scope)
+
+These features are explicitly excluded to maintain focus:
+
+- ❌ Autonomous email sending (no sending without user approval)
+- ❌ Multi-account support (only primary Gmail)
+- ❌ Mobile app (web interface only)
+- ❌ Outlook/Yahoo integration (Gmail only)
+- ❌ Spam/scam detection (Gmail handles this)
+- ❌ Email templates or canned responses
+- ❌ Email scheduling or delayed sending
+- ❌ CRM integration
+- ❌ Team/shared inbox support
+
+---
+
+## Database Schema
+
+### emails
+```sql
+CREATE TABLE emails (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    gmail_message_id TEXT UNIQUE NOT NULL,
+    thread_id TEXT,
+    sender TEXT NOT NULL,
+    subject TEXT,
+    body TEXT,
+    snippet TEXT,
+    received_date DATETIME,
+    
+    -- AI Analysis
+    ai_summary TEXT,
+    category TEXT,
+    sentiment TEXT,
+    action_required TEXT,
+    urgency_score INTEGER,
+    
+    -- Status
+    is_read BOOLEAN DEFAULT FALSE,
+    is_archived BOOLEAN DEFAULT FALSE,
+    is_starred BOOLEAN DEFAULT FALSE,
+    
+    -- Metadata
+    processed_at DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_gmail_id ON emails(gmail_message_id);
+CREATE INDEX idx_category ON emails(category);
+CREATE INDEX idx_received_date ON emails(received_date);
+```
+
+### draft_replies
+```sql
+CREATE TABLE draft_replies (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email_id INTEGER NOT NULL,
+    tone TEXT NOT NULL, -- professional, friendly, brief
+    draft_text TEXT NOT NULL,
+    was_sent BOOLEAN DEFAULT FALSE,
+    sent_at DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (email_id) REFERENCES emails(id)
+);
+```
+
+### calendar_events
+```sql
+CREATE TABLE calendar_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email_id INTEGER NOT NULL,
+    google_event_id TEXT,
+    title TEXT NOT NULL,
+    event_date DATE,
+    event_time TIME,
+    duration_minutes INTEGER,
+    participants TEXT, -- JSON array
+    location TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (email_id) REFERENCES emails(id)
+);
+```
+
+### followups
+```sql
+CREATE TABLE followups (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email_id INTEGER NOT NULL,
+    remind_at DATETIME NOT NULL,
+    reason TEXT,
+    status TEXT DEFAULT 'pending', -- pending, completed, snoozed
+    snoozed_until DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (email_id) REFERENCES emails(id)
+);
+```
+
+### user_preferences
+```sql
+CREATE TABLE user_preferences (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+---
+
+## API Integration Details
+
+### Gmail API
+
+**Authentication Flow:**
+1. User visits `/auth` endpoint
+2. Redirect to Google OAuth consent screen
+3. User grants permissions
+4. Exchange authorization code for tokens
+5. Store tokens securely (token.json)
+6. Refresh tokens automatically when expired
+
+**Rate Limits:**
+- 250 quota units per user per second
+- 1 billion quota units per day
+- messages.list = 5 units
+- messages.get = 5 units
+- messages.send = 100 units
+
+**Error Handling:**
+```python
+from googleapiclient.errors import HttpError
+
+try:
+    results = service.users().messages().list(userId='me').execute()
+except HttpError as error:
+    if error.resp.status == 429:
+        # Rate limit hit - implement exponential backoff
+        time.sleep(2 ** retry_count)
+    elif error.resp.status == 401:
+        # Token expired - refresh
+        refresh_token()
+```
+
+### Claude API
+
+**Model Selection:**
+- Use `claude-sonnet-4-20250514` (best cost/performance)
+- Fallback to `claude-haiku-4` if budget constrained
+
+**Cost Optimization:**
+```python
+# Prompt caching for repeated content
+# Cache email analysis prompt template
+# Batch similar emails together
+# Use shorter prompts for simple tasks
+
+# Example costs (approximate):
+# Sonnet 4: $3 per million input tokens, $15 per million output
+# Average email analysis: ~500 tokens in, ~200 tokens out
+# Cost per email: ~$0.004
+```
+
+**Best Practices:**
+- Use system prompts for consistent behavior
+- Implement streaming for better UX
+- Add retry logic with exponential backoff
+- Cache common prompts (save 90% on repeated content)
+
+---
+
+## Week-by-Week Implementation Plan
+
+## Week 1: Setup & Project Definition (Mar 15-21)
+
+### Goals
+- ✅ Development environment ready
+- ✅ Gmail API connection working
+- ✅ Can fetch and display 1 email
+
+### Tasks
+
+**Day 1-2: Environment Setup**
+```bash
+# Create project structure
+mkdir email-assistant
+cd email-assistant
+python -m venv venv
+source venv/bin/activate  # or venv\Scripts\activate on Windows
+
+# Install dependencies
+pip install google-api-python-client google-auth-httplib2 google-auth-oauthlib anthropic flask python-dotenv
+
+# Create project structure
+mkdir -p src/{auth,email,ai,database,ui}
+touch src/__init__.py
+touch src/auth/__init__.py src/email/__init__.py src/ai/__init__.py
+```
+
+**Day 3-4: Gmail API Setup**
+1. Go to https://console.cloud.google.com/
+2. Create new project "Email Assistant"
+3. Enable Gmail API
+4. Create OAuth 2.0 credentials
+5. Download credentials.json
+6. Create `src/auth/gmail_auth.py`:
+
+```python
+import os.path
+import pickle
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+
+SCOPES = ['https://www.googleapis.com/auth/gmail.readonly']
+
+def get_gmail_service():
+    creds = None
+    if os.path.exists('token.pickle'):
+        with open('token.pickle', 'rb') as token:
+            creds = pickle.load(token)
+    
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                'credentials.json', SCOPES)
+            creds = flow.run_local_server(port=0)
+        
+        with open('token.pickle', 'wb') as token:
+            pickle.dump(creds, token)
+    
+    return build('gmail', 'v1', credentials=creds)
+```
+
+**Day 5-6: First Email Fetch**
+Create `src/email/fetcher.py`:
+```python
+def fetch_recent_emails(service, max_results=10):
+    results = service.users().messages().list(
+        userId='me',
+        maxResults=max_results,
+        q='is:unread'
+    ).execute()
+    
+    messages = results.get('messages', [])
+    emails = []
+    
+    for msg in messages:
+        email_data = service.users().messages().get(
+            userId='me',
+            id=msg['id'],
+            format='full'
+        ).execute()
+        
+        emails.append(parse_email(email_data))
+    
+    return emails
+
+def parse_email(email_data):
+    headers = email_data['payload']['headers']
+    
+    return {
+        'id': email_data['id'],
+        'thread_id': email_data['threadId'],
+        'sender': get_header(headers, 'From'),
+        'subject': get_header(headers, 'Subject'),
+        'date': get_header(headers, 'Date'),
+        'snippet': email_data['snippet']
+    }
+```
+
+**Day 7: Test & Document**
+- Fetch 10 emails successfully
+- Print to console
+- Document setup process in README.md
+- Commit to Git
+
+### Deliverable
+- Working authentication
+- Can fetch 10 emails
+- Code committed to GitHub
+
+---
+
+## Week 2: Integration POC + System Design (Mar 22-28)
+
+### Goals
+- ✅ Database setup complete
+- ✅ Claude API integrated
+- ✅ Can analyze 10 emails and store results
+
+### Tasks
+
+**Day 1-2: Database Setup**
+Create `src/database/schema.sql` and `src/database/db.py`:
+```python
+import sqlite3
+from datetime import datetime
+
+class Database:
+    def __init__(self, db_path='email_assistant.db'):
+        self.conn = sqlite3.connect(db_path)
+        self.init_schema()
+    
+    def init_schema(self):
+        with open('src/database/schema.sql', 'r') as f:
+            self.conn.executescript(f.read())
+    
+    def insert_email(self, email_data):
+        cursor = self.conn.cursor()
+        cursor.execute("""
+            INSERT INTO emails (gmail_message_id, thread_id, sender, subject, body, snippet, received_date)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        """, (
+            email_data['id'],
+            email_data['thread_id'],
+            email_data['sender'],
+            email_data['subject'],
+            email_data.get('body', ''),
+            email_data['snippet'],
+            email_data['date']
+        ))
+        self.conn.commit()
+        return cursor.lastrowid
+```
+
+**Day 3-4: Claude API Integration**
+Create `src/ai/analyzer.py`:
+```python
+from anthropic import Anthropic
+import json
+import os
+
+client = Anthropic(api_key=os.getenv('ANTHROPIC_API_KEY'))
+
+def analyze_email(email_data):
+    prompt = f"""Analyze this email and provide structured output in JSON format.
+
+EMAIL:
+From: {email_data['sender']}
+Subject: {email_data['subject']}
+Body: {email_data.get('body', email_data['snippet'])}
+
+Provide this JSON structure:
+{{
+  "summary": "2-3 sentence summary",
+  "category": "Work|Personal|Newsletter|Finance|Travel|Shopping|Other",
+  "sentiment": "Urgent|Casual|Formal",
+  "action_required": "Reply|Schedule|Read|Archive|Flag",
+  "urgency_score": 1-10,
+  "key_dates": [],
+  "key_people": []
+}}"""
+
+    message = client.messages.create(
+        model="claude-sonnet-4-20250514",
+        max_tokens=1000,
+        messages=[{"role": "user", "content": prompt}]
+    )
+    
+    response_text = message.content[0].text
+    
+    # Parse JSON from response
+    try:
+        # Remove markdown code fences if present
+        if response_text.startswith('```'):
+            response_text = response_text.split('```')[1]
+            if response_text.startswith('json'):
+                response_text = response_text[4:]
+        
+        analysis = json.loads(response_text.strip())
+        return analysis
+    except json.JSONDecodeError as e:
+        print(f"Failed to parse JSON: {e}")
+        return None
+```
+
+**Day 5-6: Connect Pipeline**
+Create `src/main.py`:
+```python
+from auth.gmail_auth import get_gmail_service
+from email.fetcher import fetch_recent_emails
+from ai.analyzer import analyze_email
+from database.db import Database
+
+def main():
+    # Initialize
+    gmail = get_gmail_service()
+    db = Database()
+    
+    # Fetch emails
+    print("Fetching emails...")
+    emails = fetch_recent_emails(gmail, max_results=10)
+    print(f"Found {len(emails)} emails")
+    
+    # Analyze each email
+    for email in emails:
+        print(f"\nAnalyzing: {email['subject']}")
+        
+        # Get AI analysis
+        analysis = analyze_email(email)
+        
+        if analysis:
+            # Store in database
+            email_id = db.insert_email(email)
+            db.update_analysis(email_id, analysis)
+            
+            print(f"  Category: {analysis['category']}")
+            print(f"  Summary: {analysis['summary']}")
+            print(f"  Action: {analysis['action_required']}")
+    
+    print("\nProcessing complete!")
+
+if __name__ == '__main__':
+    main()
+```
+
+**Day 7: System Design**
+- Create architecture diagram
+- Document data flow
+- Write API design doc
+- Plan UI mockup
+
+### Deliverable
+- 10 emails analyzed and stored
+- System architecture documented
+
+---
+
+## Week 3: Core Chat Logic + Prompt Engineering (Apr 5-11)
+
+### Goals
+- ✅ Generate draft replies
+- ✅ Test different prompt templates
+- ✅ Basic web interface working
+
+### Tasks
+
+**Day 1-3: Draft Reply Generation**
+Create `src/ai/reply_generator.py`:
+```python
+def generate_replies(email_data, thread_context=None):
+    tones = ['professional', 'friendly', 'brief']
+    replies = {}
+    
+    for tone in tones:
+        prompt = build_reply_prompt(email_data, tone, thread_context)
+        reply = call_claude(prompt)
+        replies[tone] = reply
+    
+    return replies
+
+def build_reply_prompt(email_data, tone, thread_context):
+    tone_instructions = {
+        'professional': "formal, detailed, and polite. Use professional language.",
+        'friendly': "warm, conversational, and casual. Sound like a friend.",
+        'brief': "concise and to-the-point. Keep it under 3 sentences."
+    }
+    
+    context = f"\nPrevious conversation:\n{thread_context}" if thread_context else ""
+    
+    return f"""Generate a {tone} email reply.
+
+ORIGINAL EMAIL:
+From: {email_data['sender']}
+Subject: {email_data['subject']}
+Body: {email_data['body']}
+{context}
+
+Write a reply that is {tone_instructions[tone]}
+
+Address all questions and requests in the email.
+Sound natural and human.
+
+REPLY:"""
+```
+
+**Day 4-5: Basic Web Interface**
+Create `src/ui/app.py`:
+```python
+from flask import Flask, render_template, jsonify, request
+from database.db import Database
+from ai.reply_generator import generate_replies
+
+app = Flask(__name__)
+db = Database()
+
+@app.route('/')
+def index():
+    return render_template('dashboard.html')
+
+@app.route('/api/emails')
+def get_emails():
+    emails = db.get_recent_emails(limit=50)
+    return jsonify(emails)
+
+@app.route('/api/email/<int:email_id>')
+def get_email_detail(email_id):
+    email = db.get_email_by_id(email_id)
+    return jsonify(email)
+
+@app.route('/api/generate-replies/<int:email_id>', methods=['POST'])
+def generate_replies_endpoint(email_id):
+    email = db.get_email_by_id(email_id)
+    replies = generate_replies(email)
+    
+    # Store drafts
+    for tone, text in replies.items():
+        db.insert_draft_reply(email_id, tone, text)
+    
+    return jsonify(replies)
+
+if __name__ == '__main__':
+    app.run(debug=True)
+```
+
+Create `src/ui/templates/dashboard.html`:
+```html
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Email Assistant</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        .email-list { max-width: 800px; }
+        .email-item { 
+            border: 1px solid #ddd; 
+            padding: 15px; 
+            margin-bottom: 10px;
+            cursor: pointer;
+        }
+        .email-item:hover { background-color: #f5f5f5; }
+        .category-badge {
+            display: inline-block;
+            padding: 3px 8px;
+            border-radius: 3px;
+            font-size: 12px;
+            margin-left: 10px;
+        }
+    </style>
+</head>
+<body>
+    <h1>📧 Email Assistant</h1>
+    <div id="email-list" class="email-list"></div>
+    
+    <script>
+        async function loadEmails() {
+            const response = await fetch('/api/emails');
+            const emails = await response.json();
+            
+            const listDiv = document.getElementById('email-list');
+            listDiv.innerHTML = emails.map(email => `
+                <div class="email-item" onclick="viewEmail(${email.id})">
+                    <strong>${email.sender}</strong>
+                    <span class="category-badge">${email.category}</span>
+                    <br>
+                    <em>${email.subject}</em>
+                    <p>${email.ai_summary}</p>
+                </div>
+            `).join('');
+        }
+        
+        function viewEmail(id) {
+            window.location.href = `/email/${id}`;
+        }
+        
+        loadEmails();
+    </script>
+</body>
+</html>
+```
+
+**Day 6-7: Prompt Testing**
+- Test different prompt variations
+- Measure reply quality
+- Optimize token usage
+- Document best prompts
+
+### Deliverable
+- Working web interface
+- Can generate 3-tone replies
+- Prompt templates documented
+
+---
+
+## Week 4: External Data + Knowledge (Apr 12-18)
+
+### Goals
+- ✅ Calendar integration working
+- ✅ Meeting detection accurate
+- ✅ Can create calendar events
+
+### Tasks
+
+**Day 1-3: Calendar API Integration**
+Add to `src/auth/gmail_auth.py`:
+```python
+SCOPES = [
+    'https://www.googleapis.com/auth/gmail.readonly',
+    'https://www.googleapis.com/auth/gmail.modify',
+    'https://www.googleapis.com/auth/calendar'
+]
+
+def get_calendar_service():
+    creds = get_credentials()
+    return build('calendar', 'v3', credentials=creds)
+```
+
+Create `src/calendar/event_creator.py`:
+```python
+from datetime import datetime, timedelta
+from googleapiclient.errors import HttpError
+
+def create_calendar_event(service, event_details):
+    event = {
+        'summary': event_details['title'],
+        'description': event_details.get('description', ''),
+        'start': {
+            'dateTime': event_details['start_time'],
+            'timeZone': 'Asia/Jerusalem',
+        },
+        'end': {
+            'dateTime': event_details['end_time'],
+            'timeZone': 'Asia/Jerusalem',
+        },
+        'attendees': [
+            {'email': email} for email in event_details.get('attendees', [])
+        ],
+    }
+    
+    try:
+        created_event = service.events().insert(
+            calendarId='primary',
+            body=event
+        ).execute()
+        
+        return created_event['id']
+    except HttpError as error:
+        print(f'An error occurred: {error}')
+        return None
+```
+
+**Day 4-5: Meeting Detection**
+Create `src/ai/meeting_detector.py`:
+```python
+import re
+from dateutil import parser
+from datetime import datetime, timedelta
+
+def detect_meeting_request(email_body):
+    """Use Claude to detect meeting requests and extract details"""
+    
+    prompt = f"""Analyze this email for meeting/call requests.
+
+EMAIL:
+{email_body}
+
+If this email contains a meeting request, respond with JSON:
+{{
+  "is_meeting_request": true,
+  "title": "meeting title/subject",
+  "proposed_times": ["2024-03-20 14:00", "2024-03-21 10:00"],
+  "duration_minutes": 60,
+  "participants": ["email@example.com"],
+  "location": "Zoom/Office/Address",
+  "agenda": "brief description"
+}}
+
+If no meeting request, respond with:
+{{"is_meeting_request": false}}
+"""
+    
+    response = call_claude(prompt)
+    return parse_meeting_json(response)
+
+def parse_natural_date(date_string):
+    """Convert natural language dates to datetime"""
+    # "next Tuesday at 3pm"
+    # "tomorrow morning"
+    # "March 20th at 2:30pm"
+    
+    try:
+        return parser.parse(date_string)
+    except:
+        return None
+```
+
+**Day 6-7: Integration & Testing**
+- Connect meeting detection to email processing
+- Test calendar event creation
+- Add UI for calendar events
+- Handle edge cases
+
+### Deliverable
+- Meetings detected from emails
+- Calendar events created successfully
+- End-to-end flow working
+
+---
+
+## Week 5: Agentic Workflows (Apr 19-25)
+
+### Goals
+- ✅ System makes autonomous decisions
+- ✅ Follow-up tracking implemented
+- ✅ Smart bulk actions working
+
+### Tasks
+
+**Day 1-3: Decision Agent**
+Create `src/ai/decision_agent.py`:
+```python
+def should_reply(email_data, user_context):
+    """Decide if email needs a reply"""
+    
+    prompt = f"""Analyze if this email requires a response from the user.
+
+EMAIL:
+From: {email_data['sender']}
+Subject: {email_data['subject']}
+Body: {email_data['body']}
+Category: {email_data['category']}
+
+USER CONTEXT:
+- Has auto-archive enabled for: {user_context.get('auto_archive_categories', [])}
+- Typical response time: {user_context.get('avg_response_time', 'within 24 hours')}
+
+Decision needed:
+1. Does this require a response? (yes/no)
+2. How urgent? (low/medium/high)
+3. Suggested action? (reply/schedule/forward/archive)
+4. When to follow up if no response? (days)
+
+Respond in JSON format."""
+
+    response = call_claude(prompt)
+    return parse_decision(response)
+
+def prioritize_inbox(emails):
+    """Sort emails by urgency and importance"""
+    
+    scored_emails = []
+    for email in emails:
+        score = calculate_priority_score(email)
+        scored_emails.append((email, score))
+    
+    return sorted(scored_emails, key=lambda x: x[1], reverse=True)
+
+def calculate_priority_score(email):
+    """Calculate priority based on multiple factors"""
+    score = 0
+    
+    # Urgency
+    if email['urgency_score'] >= 8:
+        score += 50
+    elif email['urgency_score'] >= 5:
+        score += 25
+    
+    # Action required
+    if email['action_required'] == 'Reply':
+        score += 30
+    elif email['action_required'] == 'Schedule':
+        score += 40
+    
+    # Sender importance (learn from past interactions)
+    if is_important_sender(email['sender']):
+        score += 20
+    
+    # Time since received
+    hours_old = get_hours_since_received(email)
+    if hours_old > 48:
+        score += 15
+    
+    return score
+```
+
+**Day 4-5: Follow-up System**
+Create `src/followup/tracker.py`:
+```python
+from datetime import datetime, timedelta
+
+def create_followup(email_id, days=3, reason=None):
+    """Set reminder to follow up on email"""
+    remind_at = datetime.now() + timedelta(days=days)
+    
+    db.insert_followup(email_id, remind_at, reason)
+
+def check_pending_followups():
+    """Get emails that need follow-up"""
+    followups = db.get_pending_followups()
+    
+    notifications = []
+    for followup in followups:
+        email = db.get_email_by_id(followup['email_id'])
+        
+        notifications.append({
+            'email': email,
+            'reason': followup['reason'],
+            'overdue_days': (datetime.now() - followup['remind_at']).days
+        })
+    
+    return notifications
+
+def auto_snooze_email(email_id, until_date):
+    """Snooze email until specific date"""
+    db.update_followup_snooze(email_id, until_date)
+```
+
+**Day 6-7: Bulk Actions**
+- Implement "archive all newsletters"
+- Add "reply to all in category"
+- Create action templates
+- Test autonomous workflows
+
+### Deliverable
+- Agent makes smart decisions
+- Follow-ups tracked automatically
+- Bulk actions working
+
+---
+
+## Week 6: UI & Demo (Apr 26-May 2)
+
+### Goals
+- ✅ Production-ready UI
+- ✅ Demo video recorded
+- ✅ Elevator pitch written
+
+### Tasks
+
+**Day 1-3: UI Polish**
+- Upgrade to React (optional)
+- Add animations and transitions
+- Improve mobile responsiveness
+- Add loading states
+- Implement error handling UI
+
+**Day 4-5: Demo Preparation**
+Write demo script:
+```
+DEMO SCRIPT (3-5 minutes)
+
+[Scene 1: The Problem - 30 seconds]
+"I get 50+ emails a day. Reading, categorizing, and responding takes 1-2 hours daily."
+
+[Scene 2: The Solution - 30 seconds]
+"I built an AI-powered email assistant using Claude API and Gmail integration."
+
+[Scene 3: Demo - 3 minutes]
+1. Show inbox (50 unread emails)
+2. Click "Analyze Inbox" → AI processes all emails
+3. Show categorized view with summaries
+4. Click email → see 3 draft replies
+5. Edit and send reply
+6. Detect meeting → create calendar event with 1 click
+7. Show follow-up tracking
+
+[Scene 4: Results - 30 seconds]
+"Email processing time: 1.5 hours → 15 minutes (90% reduction)"
+
+[Scene 5: Tech Stack - 30 seconds]
+"Built with: Python, Flask, Gmail API, Claude API, SQLite"
+"Skills learned: API integration, prompt engineering, agentic workflows"
+```
+
+**Day 6-7: Recording & Editing**
+- Record demo video
+- Add captions
+- Upload to YouTube
+- Write elevator pitch
+
+### Deliverable
+- Polished UI
+- Professional demo video
+- Elevator pitch ready
+
+---
+
+## Week 7: Documentation & Delivery (May 3-9)
+
+### Goals
+- ✅ Complete documentation
+- ✅ Code cleaned and commented
+- ✅ Ready for submission
+
+### Tasks
+
+**Day 1-2: README Documentation**
+Create comprehensive README.md:
+```markdown
+# Smart Email Assistant
+
+AI-powered Gmail assistant that analyzes emails, generates replies, and automates inbox management.
+
+## Features
+- 📧 Email analysis with Claude AI
+- ✍️ Smart reply generation (3 tones)
+- 📅 Calendar event detection & creation
+- 🏷️ Auto-categorization
+- ⏰ Follow-up tracking
+- 🎯 Priority inbox
+
+## Tech Stack
+- Backend: Python, Flask, SQLite
+- APIs: Gmail, Calendar, Claude
+- Frontend: HTML/CSS/JavaScript (or React)
+
+## Setup Instructions
+1. Clone repository
+2. Install dependencies: `pip install -r requirements.txt`
+3. Set up Gmail API credentials
+4. Add Claude API key to .env
+5. Run: `python src/main.py`
+
+## Demo
+[YouTube video link]
+
+## Architecture
+[System diagram]
+
+## Skills Learned
+- API integration (Gmail, Calendar)
+- LLM prompt engineering
+- Agentic workflow design
+- Full-stack development
+```
+
+**Day 3-4: Code Cleanup**
+- Add docstrings to all functions
+- Remove debug print statements
+- Organize imports
+- Format code (black, autopep8)
+- Remove unused code
+
+**Day 5-6: requirements.txt & .env**
+Create `requirements.txt`:
+```
+google-api-python-client==2.88.0
+google-auth-httplib2==0.1.0
+google-auth-oauthlib==1.0.0
+anthropic==0.25.0
+flask==3.0.0
+python-dotenv==1.0.0
+python-dateutil==2.8.2
+```
+
+Create `.env.example`:
+```
+ANTHROPIC_API_KEY=your_key_here
+GMAIL_CREDENTIALS_PATH=credentials.json
+DATABASE_PATH=email_assistant.db
+```
+
+**Day 7: Final Checks**
+- Test full workflow end-to-end
+- Fix any bugs
+- Final commit
+- Submit project
+
+### Deliverable
+- Complete, documented project
+- Ready for showcase
+- Submitted on time
+
+---
+
+## Success Metrics & Evaluation
+
+### Technical Metrics
+- [ ] Successfully authenticates with Gmail API
+- [ ] Processes 50+ emails in under 5 seconds
+- [ ] AI analysis accuracy > 80%
+- [ ] Reply generation acceptance rate > 70%
+- [ ] Calendar event detection accuracy > 90%
+- [ ] Zero crashes during demo
+- [ ] Code coverage > 60% (if tests written)
+
+### Learning Metrics
+- [ ] Understands OAuth 2.0 flow
+- [ ] Can write effective LLM prompts
+- [ ] Knows how to handle API rate limits
+- [ ] Can design database schemas
+- [ ] Understands agentic workflows
+- [ ] Can build full-stack applications
+
+### Portfolio Metrics
+- [ ] GitHub repo has README, documentation
+- [ ] Demo video is professional quality
+- [ ] Can explain architecture clearly
+- [ ] Can discuss technical decisions
+- [ ] Project is showcaseable to employers
+
+---
+
+## Risk Management
+
+### Technical Risks
+
+**Risk: Gmail API quota exceeded**
+- Mitigation: Implement caching, pagination
+- Fallback: Request quota increase from Google
+
+**Risk: Claude API costs too high**
+- Mitigation: Use prompt caching, batch requests
+- Fallback: Switch to Claude Haiku for lower costs
+
+**Risk: OAuth authentication complex**
+- Mitigation: Follow official tutorials closely
+- Fallback: Use example code from Google docs
+
+**Risk: Prompt engineering takes longer than expected**
+- Mitigation: Start with simple prompts, iterate
+- Fallback: Use proven templates from documentation
+
+### Scope Risks
+
+**Risk: Feature creep**
+- Mitigation: Strict adherence to MoSCoW priorities
+- Fallback: Cut COULD HAVE features
+
+**Risk: UI takes too long**
+- Mitigation: Keep Week 1-5 UI minimal
+- Fallback: Polish in Week 6 only
+
+---
+
+## Resources & References
+
+### Documentation
+- Gmail API: https://developers.google.com/gmail/api
+- Calendar API: https://developers.google.com/calendar
+- Claude API: https://docs.anthropic.com/
+- OAuth 2.0: https://developers.google.com/identity/protocols/oauth2
+
+### Tutorials
+- Gmail Python Quickstart: https://developers.google.com/gmail/api/quickstart/python
+- Flask Tutorial: https://flask.palletsprojects.com/tutorial/
+- SQLite with Python: https://docs.python.org/3/library/sqlite3.html
+
+### Tools
+- Postman (API testing)
+- DB Browser for SQLite
+- VS Code with Python extension
+- Git/GitHub
+
+---
+
+## Appendix: Example Prompts
+
+### Email Analysis Prompt
+```
+Analyze this email and extract key information.
+
+EMAIL:
+From: {sender}
+Subject: {subject}
+Body: {body}
+
+Provide JSON output:
+{
+  "summary": "brief summary",
+  "category": "Work|Personal|etc",
+  "sentiment": "Urgent|Casual|Formal",
+  "action": "Reply|Schedule|Archive",
+  "urgency": 1-10,
+  "key_info": {
+    "dates": [],
+    "people": [],
+    "deadlines": [],
+    "questions": []
+  }
+}
+```
+
+### Reply Generation Prompt
+```
+Generate a {tone} reply to this email.
+
+ORIGINAL EMAIL:
+{email_content}
+
+TONE: {professional|friendly|brief}
+
+Instructions for {tone}:
+- Professional: Formal, detailed, polite
+- Friendly: Warm, conversational, casual
+- Brief: Under 3 sentences, direct
+
+Address all points raised.
+Maintain natural, human tone.
+
+REPLY:
+```
+
+### Meeting Detection Prompt
+```
+Detect if this email contains a meeting request.
+
+EMAIL:
+{body}
+
+Extract:
+- Is this a meeting request? (yes/no)
+- Proposed date/time
+- Duration
+- Participants
+- Location (Zoom/Office/etc)
+- Agenda
+
+JSON format:
+{
+  "is_meeting": true/false,
+  "details": {...}
+}
+```
+
+---
+
+## Contact & Support
+
+**Project Owner:** [Your Name]  
+**Timeline:** March 15 - May 9, 2026  
+**Status:** In Progress - Week 1
+
+For questions about this PRD or project, refer to:
+- GitHub Issues
+- Weekly check-ins with mentor
+- Claude Code assistance
+
+---
+
+**Last Updated:** Week 1 - March 15, 2026  
+**Version:** 1.0

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,0 +1,339 @@
+# Email Assistant - Development Progress
+
+**Project Start:** March 15, 2026  
+**Target Completion:** May 9, 2026  
+**Current Week:** Week 3
+
+---
+
+## ✅ Week 1: Setup & Project Definition (Mar 15-21) - COMPLETE
+
+- [x] Development environment setup
+- [x] Gmail API credentials obtained
+- [x] OAuth 2.0 authentication working
+- [x] Can fetch emails from Gmail
+- [x] Basic project structure created
+- [x] Git repository initialized
+
+**Deliverable:** ✅ Can authenticate and read emails
+
+---
+
+## ✅ Week 2: Integration POC + System Design (Mar 22-28) - COMPLETE
+
+- [x] Database schema designed and implemented
+- [x] SQLite database setup
+- [x] Email fetching script (last 10 unread)
+- [x] Claude API integration working
+- [x] Email analysis (summary + category) functional
+- [x] System architecture documented
+
+**Deliverable:** ✅ Can fetch 10 emails and get AI summaries
+
+---
+
+## 🔄 Week 3: Core Chat Logic + Prompt Engineering (Apr 5-11) - IN PROGRESS
+
+**Goal:** Build draft reply generation and basic web interface
+
+### Tasks Breakdown
+
+#### Task 1: Draft Reply Generation
+**Branch:** `feature/draft-reply-generation`  
+**Status:** 🔲 Not Started  
+**Scope:**
+- Create `src/ai/reply_generator.py`
+- Implement 3-tone reply system (professional, friendly, brief)
+- Add prompt templates for each tone
+- Store drafts in database
+- Write unit tests
+
+**Files to Create/Modify:**
+- `src/ai/reply_generator.py` (new)
+- `src/database/db.py` (add draft methods)
+- `tests/test_reply_generator.py` (new)
+
+**Test Coverage Target:** >80%
+
+**PR Description Template:**
+```
+## Draft Reply Generation
+
+Implements AI-powered reply drafting with 3 tone options.
+
+### Changes
+- Added reply_generator.py with tone-specific prompts
+- Extended database with draft_replies table
+- Added unit tests for all tone variations
+
+### Testing
+- Unit tests: 12 passing
+- Coverage: 85%
+
+### Examples
+[Show example generated replies]
+```
+
+---
+
+#### Task 2: Thread Context Management
+**Branch:** `feature/thread-context`  
+**Status:** 🔲 Not Started  
+**Scope:**
+- Fetch full email threads from Gmail
+- Parse thread history
+- Pass context to reply generator
+- Store thread relationships in DB
+
+**Files to Create/Modify:**
+- `src/email/thread_manager.py` (new)
+- `src/database/db.py` (add thread methods)
+- `tests/test_thread_manager.py` (new)
+
+---
+
+#### Task 3: Prompt Engineering & Testing
+**Branch:** `feature/prompt-optimization`  
+**Status:** 🔲 Not Started  
+**Scope:**
+- Test different prompt variations
+- Measure reply quality (manual review)
+- Optimize token usage
+- Document best-performing prompts
+- Add prompt caching
+
+**Files to Create/Modify:**
+- `docs/PROMPTS.md` (new - document prompts)
+- `src/ai/prompt_templates.py` (new)
+- `tests/test_prompts.py` (new)
+
+---
+
+#### Task 4: Basic Web Interface - Backend API
+**Branch:** `feature/web-api`  
+**Status:** 🔲 Not Started  
+**Scope:**
+- Set up Flask application
+- Create REST API endpoints:
+  - GET /api/emails
+  - GET /api/email/<id>
+  - POST /api/email/<id>/replies
+  - POST /api/email/<id>/send
+- Add CORS support
+- Error handling
+
+**Files to Create/Modify:**
+- `src/ui/app.py` (new)
+- `src/ui/routes.py` (new)
+- `tests/test_api.py` (new)
+
+---
+
+#### Task 5: Basic Web Interface - Frontend
+**Branch:** `feature/web-frontend`  
+**Status:** 🔲 Not Started  
+**Scope:**
+- Create HTML templates
+- Email list view
+- Email detail view with replies
+- Send email functionality
+- Basic CSS styling
+
+**Files to Create/Modify:**
+- `src/ui/templates/dashboard.html` (new)
+- `src/ui/templates/email_detail.html` (new)
+- `src/ui/static/style.css` (new)
+- `src/ui/static/app.js` (new)
+
+---
+
+#### Task 6: Integration Testing
+**Branch:** `feature/week3-integration-tests`  
+**Status:** 🔲 Not Started  
+**Scope:**
+- End-to-end tests for reply flow
+- Test with real Gmail API (sandboxed)
+- Test with real Claude API (small dataset)
+- Performance testing (response times)
+
+**Files to Create/Modify:**
+- `tests/integration/test_reply_flow.py` (new)
+- `tests/integration/test_full_pipeline.py` (new)
+
+---
+
+#### Task 7: CI/CD Setup
+**Branch:** `feature/github-actions`  
+**Status:** 🔲 Not Started  
+**Scope:**
+- Create GitHub Actions workflows
+- Automated testing on PRs
+- Code linting (black, flake8)
+- Type checking (mypy)
+- Coverage reports
+
+**Files to Create/Modify:**
+- `.github/workflows/tests.yml` (new)
+- `.github/workflows/lint.yml` (new)
+- `.github/workflows/type-check.yml` (new)
+- `.coveragerc` (new)
+- `pyproject.toml` (new)
+
+---
+
+### Week 3 Success Criteria
+
+By end of week, must demonstrate:
+- [x] Generate 3-tone draft replies for any email
+- [x] Replies consider thread context
+- [x] Web interface displays emails and drafts
+- [x] Can edit and send replies through UI
+- [x] All features have >80% test coverage
+- [x] CI pipeline runs on every PR
+
+**Deliverable:** 🎯 Can generate draft replies and basic web UI working
+
+---
+
+## 📋 Week 4: External Data + Knowledge (Apr 12-18) - UPCOMING
+
+**Goals:**
+- Calendar integration
+- Meeting detection
+- Event creation
+
+**High-Level Tasks:**
+1. Google Calendar API integration
+2. Meeting detection with Claude
+3. Natural language date parsing
+4. Calendar event creation
+5. UI for calendar features
+
+---
+
+## 📋 Week 5: Agentic Workflows (Apr 19-25) - UPCOMING
+
+**Goals:**
+- Autonomous decision-making
+- Follow-up tracking
+- Smart bulk actions
+
+**High-Level Tasks:**
+1. Decision agent implementation
+2. Priority scoring system
+3. Follow-up tracking
+4. Reminder system
+5. Bulk action handlers
+
+---
+
+## 📋 Week 6: UI & Demo (Apr 26-May 2) - UPCOMING
+
+**Goals:**
+- Production-ready UI
+- Demo video
+- Elevator pitch
+
+**High-Level Tasks:**
+1. UI polish and animations
+2. Error handling improvements
+3. Demo script writing
+4. Video recording
+5. Deployment (optional)
+
+---
+
+## 📋 Week 7: Documentation & Delivery (May 3-9) - UPCOMING
+
+**Goals:**
+- Complete documentation
+- Code cleanup
+- Final submission
+
+**High-Level Tasks:**
+1. Comprehensive README
+2. Code comments and docstrings
+3. Setup instructions
+4. requirements.txt finalization
+5. Final testing
+
+---
+
+## Development Metrics
+
+### Code Quality
+- Test Coverage: Target >80%
+- Type Hints: 100% of public functions
+- Docstrings: 100% of public functions
+- Linting: Zero errors (black, flake8)
+
+### Git Stats
+- Total Commits: [Auto-updated]
+- Open PRs: [Auto-updated]
+- Merged PRs: [Auto-updated]
+
+### Time Tracking
+- Week 1: [Hours spent]
+- Week 2: [Hours spent]
+- Week 3: [Hours spent]
+- Total: [Hours spent]
+
+---
+
+## Engineering Decisions Log
+
+### Decision 1: Database Choice
+**Date:** Week 1  
+**Decision:** Use SQLite  
+**Reasoning:** Lightweight, no server setup, sufficient for prototype  
+**Alternatives Considered:** PostgreSQL (overkill for MVP)
+
+### Decision 2: Web Framework
+**Date:** Week 2  
+**Decision:** Flask  
+**Reasoning:** Simple, lightweight, fast to prototype  
+**Alternatives Considered:** FastAPI (more complex for our needs)
+
+### Decision 3: Frontend Approach
+**Date:** Week 3  
+**Decision:** HTML/CSS/JS (vanilla)  
+**Reasoning:** Keep it simple, upgrade to React in Week 6 if time permits  
+**Alternatives Considered:** React from start (premature optimization)
+
+### Decision 4: AI Model Selection
+**Date:** Week 2  
+**Decision:** Claude Sonnet 4  
+**Reasoning:** Best cost/performance, good for prototype  
+**Alternatives Considered:** GPT-4 (more expensive), Haiku (less capable)
+
+---
+
+## Blockers & Issues
+
+### Active Blockers
+*None currently*
+
+### Resolved Issues
+1. **Gmail API quota limits** - Resolved by implementing caching
+2. **OAuth token expiration** - Resolved with automatic refresh
+
+---
+
+## Next Actions
+
+**Immediate Next Steps (Week 3):**
+1. Break Week 3 into 7 specific tasks ✅ (done above)
+2. Set up GitHub Actions CI/CD
+3. Start Task 1: Draft Reply Generation
+4. Create first PR
+5. Merge and move to Task 2
+
+**How to Continue:**
+```bash
+claude "Start Week 3 Task 1: Draft Reply Generation. Create feature branch and implement with tests."
+```
+
+---
+
+**Last Updated:** [Date]  
+**Current Focus:** Week 3 - Core Chat Logic

--- a/docs/USER_STORY_TEMPLATE.md
+++ b/docs/USER_STORY_TEMPLATE.md
@@ -1,0 +1,127 @@
+# User Story Template
+
+Use this template when creating feature issues for the email assistant project.
+
+---
+
+## Title
+[Imperative mood: "Add user authentication", not "Adding..."]
+
+## Labels
+- `user-story`
+- `size:S` or `size:M` or `size:L` or `size:XL`
+- `priority:critical` or `priority:high` or `priority:medium` or `priority:low`
+- `area:api` or `area:frontend` or `area:ai` or `area:database` or `area:cli`
+
+## Body
+
+```markdown
+## User Story
+
+**As a** [role],
+**I want** [capability],
+**So that** [benefit].
+
+## Context
+
+[1-3 sentences explaining why this story exists now. Link to relevant docs.]
+
+See: [`docs/PRD.md#section`](docs/PRD.md#section) | [`docs/PROGRESS.md#week-N`](docs/PROGRESS.md#week-N)
+
+## Acceptance Criteria
+
+- [ ] [Concrete, binary pass/fail condition]
+- [ ] [Another criterion]
+- [ ] [Another criterion]
+- [ ] All functions have type hints
+- [ ] >80% test coverage
+
+## Test Scenarios
+
+| Scenario | Given | When | Then |
+|---|---|---|---|
+| [Happy path] | [precondition] | [action] | [expected result] |
+| [Edge case] | [precondition] | [action] | [expected result] |
+| [Error case] | [precondition] | [action] | [expected result] |
+
+## Technical Notes
+
+[Optional - only if there are specific implementation constraints]
+
+- [Relevant architecture decision]
+- [API contract or data model notes]
+
+## Sub-Tasks
+
+### Backend (BE)
+- [ ] [Specific backend task]
+- [ ] [Another task]
+
+### Frontend (FE)
+- [ ] [Specific frontend task]
+
+### Integration
+- [ ] [Integration task if needed]
+
+### QA
+- [ ] [Test implementation task]
+- [ ] [Coverage verification]
+```
+
+---
+
+## Example: Week 3 Task 1
+
+```markdown
+## User Story
+
+**As a** user,
+**I want** AI to generate draft email replies in 3 different tones,
+**So that** I can quickly respond with appropriate formality.
+
+## Context
+
+Week 3 core feature - implements AI reply generation which is central to the email assistant value proposition.
+
+See: [`docs/PRD.md#feature-3-smart-reply-generation`](docs/PRD.md#feature-3-smart-reply-generation)
+
+## Acceptance Criteria
+
+- [ ] Can generate professional tone reply
+- [ ] Can generate friendly tone reply
+- [ ] Can generate brief tone reply
+- [ ] Drafts stored in database with tone label
+- [ ] All functions have type hints
+- [ ] >80% test coverage
+
+## Test Scenarios
+
+| Scenario | Given | When | Then |
+|---|---|---|---|
+| Professional reply | Formal meeting request email | Request professional tone | Returns formal reply with proper salutation |
+| Friendly reply | Casual message from colleague | Request friendly tone | Returns warm, conversational reply |
+| Brief reply | Simple yes/no question | Request brief tone | Returns reply under 3 sentences |
+| Thread context | Email is part of 5-message thread | Generate any tone | Reply references previous context |
+
+## Technical Notes
+
+- Use Claude Sonnet 4 API (best cost/performance)
+- Implement prompt caching to save 90% on repeated template tokens
+- Store tone as enum: PROFESSIONAL, FRIENDLY, BRIEF
+
+## Sub-Tasks
+
+### Backend (BE)
+- [ ] Create `src/ai/reply_generator.py`
+- [ ] Implement `generate_replies(email_data, tones=['professional', 'friendly', 'brief'])`
+- [ ] Add prompt templates in `src/ai/prompt_templates.py`
+- [ ] Extend `src/database/db.py` with `insert_draft_reply()` and `get_drafts_for_email()`
+- [ ] Add type hints to all functions
+
+### QA
+- [ ] Write `tests/test_reply_generator.py` with tests for each tone
+- [ ] Test with real Gmail API data (use test account)
+- [ ] Verify database storage and retrieval
+- [ ] Measure and verify >80% code coverage
+- [ ] Performance test: <2 seconds per reply generation
+```


### PR DESCRIPTION
Closes #11

## Summary
- Project docs: PRD, weekly progress, GitHub workflow, story + bug templates
- Four Claude Code skills: `github`, `create-user-story`, `create-bug`, `pr-workflow` (used to ship #1, #3, #5, #7, #9)
- `tests/integration/__init__.py` placeholder for future integration tests

## Changes
- `docs/PRD.md` — product spec
- `docs/PROGRESS.md` — weekly tracker
- `docs/GITHUB_WORKFLOW.md` — workflow conventions
- `docs/USER_STORY_TEMPLATE.md`, `docs/BUG_REPORT_TEMPLATE.md` — ticket templates
- `.claude/skills/*.md` — four reusable skills
- `tests/integration/__init__.py` — placeholder

## Test Plan
- [x] No code changes, but CI should still pass on the existing test suite