### PR TITLE
feat: add Telegram bot scaffolding with webhook + single-user auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
 ANTHROPIC_API_KEY=your_key_here
 GMAIL_CREDENTIALS_PATH=credentials.json
 DATABASE_PATH=email_assistant.db
+
+# Telegram bot (Week 3)
+TELEGRAM_BOT_TOKEN=your_botfather_token
+TELEGRAM_AUTHORIZED_CHAT_ID=your_chat_id
+TELEGRAM_WEBHOOK_URL=https://your-tunnel.example.com/telegram/webhook
+TELEGRAM_WEBHOOK_SECRET=any_random_string

--- a/app/database/db.py
+++ b/app/database/db.py
@@ -88,6 +88,12 @@ def init_db():
             value TEXT NOT NULL,
             updated_at TEXT DEFAULT (datetime('now'))
         );
+
+        CREATE TABLE IF NOT EXISTS telegram_users (
+            chat_id INTEGER PRIMARY KEY,
+            created_at TEXT DEFAULT (datetime('now')),
+            last_seen_at TEXT DEFAULT (datetime('now'))
+        );
     """)
     conn.close()
 
@@ -169,5 +175,27 @@ def get_unprocessed_emails() -> list[dict]:
     try:
         rows = conn.execute("SELECT * FROM emails WHERE processed_at IS NULL").fetchall()
         return [dict(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def get_or_create_telegram_user(chat_id: int) -> dict:
+    """Insert the chat_id if missing, bump last_seen_at, return the row."""
+    conn = get_connection()
+    try:
+        conn.execute(
+            "INSERT OR IGNORE INTO telegram_users (chat_id) VALUES (?)",
+            (chat_id,),
+        )
+        conn.execute(
+            "UPDATE telegram_users SET last_seen_at = ? WHERE chat_id = ?",
+            (datetime.now().isoformat(), chat_id),
+        )
+        conn.commit()
+        row = conn.execute(
+            "SELECT * FROM telegram_users WHERE chat_id = ?",
+            (chat_id,),
+        ).fetchone()
+        return dict(row)
     finally:
         conn.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,19 +1,56 @@
+import logging
+import os
+
 from dotenv import load_dotenv
 
 load_dotenv()
 
-from fastapi import FastAPI, HTTPException, Query  # noqa: E402
+from fastapi import FastAPI, Header, HTTPException, Query, Request  # noqa: E402
 
 from app.gmail.service import get_recent_emails  # noqa: E402
 from app.ai.analyzer import analyze_email  # noqa: E402
 from app.database import db  # noqa: E402
+from app.telegram import bot as telegram_bot  # noqa: E402
+
+logger = logging.getLogger(__name__)
 
 app = FastAPI(title="AI Email Copilot")
 
 
 @app.on_event("startup")
-def startup():
+async def startup():
     db.init_db()
+
+    webhook_url = os.getenv("TELEGRAM_WEBHOOK_URL")
+    secret_token = os.getenv("TELEGRAM_WEBHOOK_SECRET")
+    if not webhook_url:
+        logger.warning("TELEGRAM_WEBHOOK_URL not set; skipping Telegram webhook registration")
+        return
+
+    await telegram_bot.initialize()
+    application = telegram_bot.get_application()
+    await application.bot.set_webhook(url=webhook_url, secret_token=secret_token)
+    logger.info("Telegram webhook registered at %s", webhook_url)
+
+
+@app.on_event("shutdown")
+async def shutdown():
+    await telegram_bot.shutdown()
+
+
+@app.post("/telegram/webhook")
+async def telegram_webhook(
+    request: Request,
+    x_telegram_bot_api_secret_token: str | None = Header(default=None),
+):
+    """Receive updates from Telegram and dispatch through the bot Application."""
+    expected_secret = os.getenv("TELEGRAM_WEBHOOK_SECRET")
+    if expected_secret and x_telegram_bot_api_secret_token != expected_secret:
+        raise HTTPException(status_code=403, detail="Invalid secret token")
+
+    payload = await request.json()
+    await telegram_bot.process_update_from_json(payload)
+    return {"ok": True}
 
 
 @app.get("/")

--- a/app/telegram/bot.py
+++ b/app/telegram/bot.py
@@ -1,0 +1,43 @@
+"""Telegram bot Application instance + lifecycle helpers."""
+
+import os
+
+from telegram import Update
+from telegram.ext import Application
+
+_application: Application | None = None
+
+
+def get_application() -> Application:
+    """Build (lazily) and return the Telegram Application singleton."""
+    global _application
+    if _application is None:
+        token = os.getenv("TELEGRAM_BOT_TOKEN")
+        if not token:
+            raise RuntimeError("TELEGRAM_BOT_TOKEN is not set")
+        _application = Application.builder().token(token).build()
+        from app.telegram import handlers
+
+        handlers.register(_application)
+    return _application
+
+
+async def initialize() -> None:  # pragma: no cover
+    """Initialize the Application; call from FastAPI startup."""
+    app = get_application()
+    await app.initialize()
+
+
+async def shutdown() -> None:  # pragma: no cover
+    """Shut down the Application; call from FastAPI shutdown."""
+    global _application
+    if _application is not None:
+        await _application.shutdown()
+        _application = None
+
+
+async def process_update_from_json(payload: dict) -> None:  # pragma: no cover
+    """Parse a webhook payload and dispatch it through registered handlers."""
+    app = get_application()
+    update = Update.de_json(payload, app.bot)
+    await app.process_update(update)

--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -1,0 +1,69 @@
+"""Telegram bot command handlers + single-user auth guard."""
+
+import logging
+import os
+from functools import wraps
+
+from telegram import Update
+from telegram.ext import Application, CommandHandler, ContextTypes
+
+from app.database import db
+
+logger = logging.getLogger(__name__)
+
+WELCOME = (
+    "Welcome to AI Email Copilot.\n\n"
+    "Commands:\n"
+    "/unread - list unread emails\n"
+    "/analyze - run AI analysis on unprocessed emails\n"
+    "/inbox - show last analyzed emails\n"
+    "/reply <id> - draft a reply to an email\n"
+    "/help - show this message"
+)
+
+
+def _is_authorized(chat_id: int | None) -> bool:
+    """Check whether chat_id matches TELEGRAM_AUTHORIZED_CHAT_ID env var."""
+    if chat_id is None:
+        return False
+    authorized_id = os.getenv("TELEGRAM_AUTHORIZED_CHAT_ID")
+    if not authorized_id:
+        return False
+    try:
+        return int(authorized_id) == chat_id
+    except ValueError:
+        return False
+
+
+def authorized_only(handler):
+    """Drop updates from any chat_id other than TELEGRAM_AUTHORIZED_CHAT_ID."""
+
+    @wraps(handler)
+    async def wrapper(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        chat = update.effective_chat
+        chat_id = chat.id if chat else None
+        if not _is_authorized(chat_id):
+            logger.info("Dropped update from unauthorized chat_id=%s", chat_id)
+            return None
+        db.get_or_create_telegram_user(chat_id)
+        return await handler(update, context)
+
+    return wrapper
+
+
+@authorized_only
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Reply to /start with the welcome message."""
+    await update.message.reply_text(WELCOME)
+
+
+@authorized_only
+async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Reply to /help with the welcome message."""
+    await update.message.reply_text(WELCOME)
+
+
+def register(application: Application) -> None:
+    """Register all command handlers on the given Application."""
+    application.add_handler(CommandHandler("start", start))
+    application.add_handler(CommandHandler("help", help_command))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ omit = [
     "app/*/__init__.py",
     "app/main.py",
     "app/gmail/auth.py",       # OAuth flow — covered by integration tests
+    "app/telegram/bot.py",     # Application wiring — covered by manual e2e
 ]
 
 [tool.coverage.report]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ anthropic
 pydantic
 python-dateutil
 httpx
+python-telegram-bot>=21.0

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -10,7 +10,14 @@ def test_init_db_creates_tables():
         for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
     }
     conn.close()
-    expected = {"emails", "draft_replies", "calendar_events", "followups", "user_preferences"}
+    expected = {
+        "emails",
+        "draft_replies",
+        "calendar_events",
+        "followups",
+        "user_preferences",
+        "telegram_users",
+    }
     assert expected.issubset(tables)
 
 
@@ -111,3 +118,20 @@ def test_get_unprocessed_emails_excludes_analyzed():
     unprocessed_ids = {e["gmail_message_id"] for e in db.get_unprocessed_emails()}
     assert "raw" in unprocessed_ids
     assert "done" not in unprocessed_ids
+
+
+def test_get_or_create_telegram_user_creates_on_first_call():
+    user = db.get_or_create_telegram_user(123456789)
+    assert user["chat_id"] == 123456789
+    assert user["created_at"] is not None
+    assert user["last_seen_at"] is not None
+
+
+def test_get_or_create_telegram_user_bumps_last_seen():
+    first = db.get_or_create_telegram_user(987654321)
+    second = db.get_or_create_telegram_user(987654321)
+    assert first["chat_id"] == second["chat_id"]
+    # last_seen_at must have advanced (or at least not gone backwards)
+    assert second["last_seen_at"] >= first["last_seen_at"]
+    # created_at must NOT change on a re-call
+    assert first["created_at"] == second["created_at"]

--- a/tests/unit/test_telegram_auth.py
+++ b/tests/unit/test_telegram_auth.py
@@ -1,0 +1,77 @@
+"""Tests for the @authorized_only decorator and _is_authorized helper."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.telegram import handlers
+from app.telegram.handlers import _is_authorized, authorized_only
+
+
+def test_is_authorized_true_on_match(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    assert _is_authorized(42) is True
+
+
+def test_is_authorized_false_on_mismatch(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    assert _is_authorized(99) is False
+
+
+def test_is_authorized_false_when_env_unset(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_AUTHORIZED_CHAT_ID", raising=False)
+    assert _is_authorized(42) is False
+
+
+def test_is_authorized_false_when_chat_id_none(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    assert _is_authorized(None) is False
+
+
+def test_is_authorized_false_on_non_numeric_env(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "not-a-number")
+    assert _is_authorized(42) is False
+
+
+@pytest.mark.asyncio
+async def test_authorized_only_forwards_when_authorized(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    inner = AsyncMock(return_value="called")
+    wrapped = authorized_only(inner)
+    update = MagicMock()
+    update.effective_chat.id = 42
+    result = await wrapped(update, None)
+    assert result == "called"
+    inner.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_authorized_only_drops_when_unauthorized(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    inner = AsyncMock()
+    wrapped = authorized_only(inner)
+    update = MagicMock()
+    update.effective_chat.id = 99
+    result = await wrapped(update, None)
+    assert result is None
+    inner.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_start_replies_with_welcome(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    update = MagicMock()
+    update.effective_chat.id = 42
+    update.message.reply_text = AsyncMock()
+    await handlers.start(update, None)
+    update.message.reply_text.assert_awaited_once_with(handlers.WELCOME)
+
+
+@pytest.mark.asyncio
+async def test_help_replies_with_welcome(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    update = MagicMock()
+    update.effective_chat.id = 42
+    update.message.reply_text = AsyncMock()
+    await handlers.help_command(update, None)
+    update.message.reply_text.assert_awaited_once_with(handlers.WELCOME)

--- a/tests/unit/test_telegram_webhook.py
+++ b/tests/unit/test_telegram_webhook.py
@@ -1,0 +1,56 @@
+"""Tests for the POST /telegram/webhook route in app/main.py."""
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def _payload() -> dict:
+    return {"update_id": 1, "message": {"message_id": 1, "text": "/start"}}
+
+
+def test_webhook_rejects_missing_secret(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "expected")
+    response = client.post("/telegram/webhook", json=_payload())
+    assert response.status_code == 403
+
+
+def test_webhook_rejects_wrong_secret(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "expected")
+    response = client.post(
+        "/telegram/webhook",
+        json=_payload(),
+        headers={"X-Telegram-Bot-Api-Secret-Token": "wrong"},
+    )
+    assert response.status_code == 403
+
+
+def test_webhook_dispatches_when_secret_matches(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "expected")
+    with patch(
+        "app.main.telegram_bot.process_update_from_json",
+        new=AsyncMock(return_value=None),
+    ) as process_mock:
+        response = client.post(
+            "/telegram/webhook",
+            json=_payload(),
+            headers={"X-Telegram-Bot-Api-Secret-Token": "expected"},
+        )
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    process_mock.assert_awaited_once_with(_payload())
+
+
+def test_webhook_skips_secret_check_when_unset(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_WEBHOOK_SECRET", raising=False)
+    with patch(
+        "app.main.telegram_bot.process_update_from_json",
+        new=AsyncMock(return_value=None),
+    ) as process_mock:
+        response = client.post("/telegram/webhook", json=_payload())
+    assert response.status_code == 200
+    process_mock.assert_awaited_once()


### PR DESCRIPTION
Closes #13

## Summary
- Wires `python-telegram-bot` v22 into FastAPI as the user interface for AI Email Copilot, replacing the dropped web UI scope from Week 3
- `POST /telegram/webhook` verifies the `X-Telegram-Bot-Api-Secret-Token` header and dispatches updates through a lazy Application singleton
- `@authorized_only` decorator silently drops updates from any chat_id other than `TELEGRAM_AUTHORIZED_CHAT_ID`; `/start` and `/help` reply with the welcome + command list to the authorized user

## Changes
- `app/main.py` — added webhook route, async startup/shutdown hooks, `setWebhook` registration on boot
- `app/telegram/bot.py` — Application singleton with lazy init + lifecycle helpers
- `app/telegram/handlers.py` — `_is_authorized` + `@authorized_only` + `/start` + `/help` + handler registration
- `app/database/db.py` — `telegram_users` table + `get_or_create_telegram_user` UPSERT
- `.env.example` — added the four `TELEGRAM_*` vars
- `requirements.txt` — added `python-telegram-bot>=21.0`
- `pyproject.toml` — added `app/telegram/bot.py` to coverage omit (pure I/O wiring)
- `tests/unit/test_telegram_auth.py` — 9 tests covering auth helper, decorator, and command handlers
- `tests/unit/test_telegram_webhook.py` — 4 tests covering secret-token verification and webhook routing
- `tests/unit/test_db.py` — added 2 tests for the new `telegram_users` helpers

## Test Plan
- [x] `pytest tests/ --cov=app` passes (34 tests, 92.50% coverage)
- [x] `black app/ tests/` clean
- [x] `flake8 app/ tests/` clean
- [x] Manual end-to-end: started uvicorn with cloudflared tunnel, confirmed `setWebhook` log line, sent `/start` from authorized chat → got welcome reply, verified silent drop from unauthorized chat, verified 403 on missing/wrong secret header

## Acceptance Criteria from #13
- [x] `python-telegram-bot>=21.0` added to `requirements.txt`
- [x] `POST /telegram/webhook` accepts updates, verifies `X-Telegram-Bot-Api-Secret-Token`, returns 200
- [x] Unauthorized `chat_id` silently dropped (no Telegram reply, no info leak)
- [x] `/start` and `/help` respond with welcome + command list to the authorized user
- [x] On FastAPI startup, app calls `setWebhook` automatically when `TELEGRAM_WEBHOOK_URL` is set; logs warning + skips otherwise
- [x] `telegram_users(chat_id, created_at, last_seen_at)` table created in `init_db()`
- [x] All public functions have type hints + docstrings
- [x] Coverage ≥80% on auth + handler routing logic (live network paths excluded with `# pragma: no cover`)
- [x] `black` + `flake8` clean