### PR TITLE
feat: add Telegram pull commands — /unread, /analyze, /inbox

### DIFF
--- a/app/telegram/formatting.py
+++ b/app/telegram/formatting.py
@@ -1,0 +1,86 @@
+"""Telegram MarkdownV2 escaping + email/analysis renderers + 4096-char chunking."""
+
+# Per https://core.telegram.org/bots/api#markdownv2-style — these MUST be escaped
+# anywhere they appear in user-supplied text, otherwise the bot API returns
+# "Bad Request: can't parse entities".
+_MD_V2_RESERVED = r"_*[]()~`>#+-=|{}.!\\"
+_MD_V2_TRANSLATION = str.maketrans({c: f"\\{c}" for c in _MD_V2_RESERVED})
+
+TELEGRAM_MAX_MESSAGE_LEN = 4096
+
+
+def escape_markdown_v2(text: str | None) -> str:
+    """Escape all Telegram MarkdownV2 reserved characters in a single pass."""
+    if not text:
+        return ""
+    return text.translate(_MD_V2_TRANSLATION)
+
+
+def _priority_emoji(urgency: int | None) -> str:
+    """Map an urgency_score (1-10) to a colored circle. None / unknown → grey."""
+    if urgency is None:
+        return "⚪"
+    if urgency >= 9:
+        return "🔴"
+    if urgency >= 5:
+        return "🟡"
+    return "🟢"
+
+
+def format_unread_entry(email: dict, index: int) -> str:
+    """Render one Gmail-fetched email as a numbered MarkdownV2 block."""
+    sender = escape_markdown_v2(email.get("sender") or "Unknown sender")
+    subject = escape_markdown_v2(email.get("subject") or "(no subject)")
+    snippet = escape_markdown_v2(email.get("snippet") or "")
+    return f"*{index}\\.* {sender}\n*Subject:* {subject}\n{snippet}"
+
+
+def format_analysis_entry(email: dict, analysis: dict, index: int) -> str:
+    """Render one email + Claude analysis result as a numbered MarkdownV2 block."""
+    sender = escape_markdown_v2(email.get("sender") or "Unknown sender")
+    subject = escape_markdown_v2(email.get("subject") or "(no subject)")
+    category = escape_markdown_v2(analysis.get("category") or "Unknown")
+    urgency = analysis.get("urgency_score")
+    urgency_str = escape_markdown_v2(f"{urgency}/10" if urgency is not None else "n/a")
+    summary = escape_markdown_v2(analysis.get("summary") or "")
+    emoji = _priority_emoji(urgency)
+    return (
+        f"{emoji} *{index}\\.* {sender} — {subject}\n"
+        f"*Category:* {category} \\| *Urgency:* {urgency_str}\n"
+        f"{summary}"
+    )
+
+
+def format_inbox_entry(row: dict, index: int) -> str:
+    """Render one analyzed-email DB row as a numbered MarkdownV2 block."""
+    sender = escape_markdown_v2(row.get("sender") or "Unknown sender")
+    subject = escape_markdown_v2(row.get("subject") or "(no subject)")
+    summary = escape_markdown_v2(row.get("ai_summary") or "")
+    emoji = _priority_emoji(row.get("urgency_score"))
+    return f"{emoji} *{index}\\.* {sender} — {subject}\n{summary}"
+
+
+def chunk_messages(blocks: list[str], max_len: int = TELEGRAM_MAX_MESSAGE_LEN) -> list[str]:
+    """Pack blocks into messages of at most max_len characters.
+
+    Blocks are joined with a blank line. A single oversized block is sent as
+    its own message rather than being split mid-record (per Story B AC).
+    """
+    if not blocks:
+        return []
+    separator = "\n\n"
+    messages: list[str] = []
+    current: list[str] = []
+    current_len = 0
+    for block in blocks:
+        addition = len(block) if not current else len(separator) + len(block)
+        if current and current_len + addition > max_len:
+            messages.append(separator.join(current))
+            current = [block]
+            current_len = len(block)
+        else:
+            current.append(block)
+            current_len += addition
+    if current:
+        messages.append(separator.join(current))
+    return messages

--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -5,9 +5,22 @@ import os
 from functools import wraps
 
 from telegram import Update
+from telegram.constants import ParseMode
 from telegram.ext import Application, CommandHandler, ContextTypes
 
+from app.ai.analyzer import analyze_email
 from app.database import db
+from app.gmail.service import get_recent_emails as gmail_fetch_recent
+from app.telegram.formatting import (
+    chunk_messages,
+    escape_markdown_v2,
+    format_analysis_entry,
+    format_inbox_entry,
+    format_unread_entry,
+)
+
+INBOX_DEFAULT_LIMIT = 10
+UNREAD_DEFAULT_LIMIT = 20
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +76,60 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     await update.message.reply_text(WELCOME)
 
 
+async def _send_chunks(update: Update, blocks: list[str], empty_message: str) -> None:
+    """Render blocks via chunk_messages and send each as MarkdownV2."""
+    if not blocks:
+        await update.message.reply_text(empty_message)
+        return
+    for chunk in chunk_messages(blocks):
+        await update.message.reply_text(chunk, parse_mode=ParseMode.MARKDOWN_V2)
+
+
+@authorized_only
+async def unread(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Fetch unread emails from Gmail and reply with a numbered list."""
+    try:
+        emails = gmail_fetch_recent(max_results=UNREAD_DEFAULT_LIMIT, unread_only=True)
+    except RuntimeError as exc:
+        logger.exception("Gmail fetch failed for /unread")
+        await update.message.reply_text(f"Gmail error: {exc}")
+        return
+    blocks = [format_unread_entry(email, i + 1) for i, email in enumerate(emails)]
+    await _send_chunks(update, blocks, "No unread emails.")
+
+
+@authorized_only
+async def analyze(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Run Claude on every unprocessed email in the DB and reply with results."""
+    pending = db.get_unprocessed_emails()
+    blocks: list[str] = []
+    for index, email in enumerate(pending, start=1):
+        analysis = analyze_email(email)
+        if not analysis:
+            blocks.append(
+                f"⚠️ *{index}\\.* {escape_markdown_v2(email.get('sender') or 'Unknown')} "
+                f"— analysis failed"
+            )
+            continue
+        db.update_analysis(email["gmail_message_id"], analysis)
+        blocks.append(format_analysis_entry(email, analysis, index))
+
+    await _send_chunks(update, blocks, "No emails to analyze.")
+
+
+@authorized_only
+async def inbox(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Show the most recent analyzed emails from the DB with priority indicators."""
+    rows = db.get_recent_emails(limit=INBOX_DEFAULT_LIMIT)
+    analyzed = [row for row in rows if row.get("processed_at")]
+    blocks = [format_inbox_entry(row, i + 1) for i, row in enumerate(analyzed)]
+    await _send_chunks(update, blocks, "No analyzed emails yet.")
+
+
 def register(application: Application) -> None:
     """Register all command handlers on the given Application."""
     application.add_handler(CommandHandler("start", start))
     application.add_handler(CommandHandler("help", help_command))
+    application.add_handler(CommandHandler("unread", unread))
+    application.add_handler(CommandHandler("analyze", analyze))
+    application.add_handler(CommandHandler("inbox", inbox))

--- a/tests/unit/test_telegram_formatting.py
+++ b/tests/unit/test_telegram_formatting.py
@@ -1,0 +1,128 @@
+"""Tests for app/telegram/formatting.py — escaping, renderers, chunking."""
+
+from app.telegram.formatting import (
+    chunk_messages,
+    escape_markdown_v2,
+    format_analysis_entry,
+    format_inbox_entry,
+    format_unread_entry,
+)
+
+
+def test_escape_markdown_v2_passes_plain_text_through():
+    assert escape_markdown_v2("hello world") == "hello world"
+
+
+def test_escape_markdown_v2_returns_empty_for_none():
+    assert escape_markdown_v2(None) == ""
+
+
+def test_escape_markdown_v2_returns_empty_for_empty_string():
+    assert escape_markdown_v2("") == ""
+
+
+def test_escape_markdown_v2_escapes_all_reserved_chars():
+    reserved = r"_*[]()~`>#+-=|{}.!\\"
+    escaped = escape_markdown_v2(reserved)
+    for char in reserved:
+        assert f"\\{char}" in escaped
+
+
+def test_escape_markdown_v2_escapes_email_address_dot():
+    assert escape_markdown_v2("alice@example.com") == "alice@example\\.com"
+
+
+def test_format_unread_entry_happy_path():
+    email = {"sender": "alice@example.com", "subject": "Hi", "snippet": "Just checking in"}
+    block = format_unread_entry(email, 1)
+    assert "*1\\.*" in block
+    assert "alice@example\\.com" in block
+    assert "*Subject:* Hi" in block
+    assert "Just checking in" in block
+
+
+def test_format_unread_entry_handles_missing_fields():
+    block = format_unread_entry({}, 2)
+    assert "*2\\.*" in block
+    assert "Unknown sender" in block
+    assert "\\(no subject\\)" in block
+
+
+def test_format_analysis_entry_high_urgency_gets_red():
+    email = {"sender": "boss@corp.com", "subject": "URGENT"}
+    analysis = {"category": "Work", "urgency_score": 10, "summary": "Reply ASAP"}
+    block = format_analysis_entry(email, analysis, 1)
+    assert block.startswith("🔴")
+    assert "*Category:* Work" in block
+    assert "10/10" in block
+    assert "Reply ASAP" in block
+
+
+def test_format_analysis_entry_medium_urgency_gets_yellow():
+    block = format_analysis_entry({"sender": "x"}, {"urgency_score": 6}, 1)
+    assert block.startswith("🟡")
+
+
+def test_format_analysis_entry_low_urgency_gets_green():
+    block = format_analysis_entry({"sender": "x"}, {"urgency_score": 2}, 1)
+    assert block.startswith("🟢")
+
+
+def test_format_analysis_entry_missing_urgency_shows_na():
+    block = format_analysis_entry({"sender": "x"}, {"category": "Other"}, 1)
+    assert block.startswith("⚪")
+    assert "n/a" in block
+
+
+def test_format_inbox_entry_happy_path():
+    row = {
+        "sender": "alice@example.com",
+        "subject": "Update",
+        "ai_summary": "All good.",
+        "urgency_score": 9,
+    }
+    block = format_inbox_entry(row, 1)
+    assert block.startswith("🔴")
+    assert "alice@example\\.com" in block
+    assert "Update" in block
+    assert "All good\\." in block
+
+
+def test_format_inbox_entry_handles_missing_analysis():
+    block = format_inbox_entry({"sender": "x", "subject": "y"}, 1)
+    assert block.startswith("⚪")
+
+
+def test_chunk_messages_empty_list_returns_empty():
+    assert chunk_messages([]) == []
+
+
+def test_chunk_messages_single_block_fits_in_one_message():
+    assert chunk_messages(["hello"]) == ["hello"]
+
+
+def test_chunk_messages_joins_blocks_under_limit_with_blank_line():
+    result = chunk_messages(["a", "b", "c"])
+    assert result == ["a\n\nb\n\nc"]
+
+
+def test_chunk_messages_splits_when_total_exceeds_limit():
+    blocks = ["x" * 100, "y" * 100, "z" * 100]
+    result = chunk_messages(blocks, max_len=210)
+    assert len(result) == 2
+    assert result[0] == "x" * 100 + "\n\n" + "y" * 100
+    assert result[1] == "z" * 100
+
+
+def test_chunk_messages_oversized_single_block_gets_own_message():
+    blocks = ["short", "x" * 200, "another short"]
+    result = chunk_messages(blocks, max_len=50)
+    assert "short" in result[0]
+    assert "x" * 200 in result[1]
+    assert "another short" in result[2]
+
+
+def test_chunk_messages_never_splits_mid_block():
+    big_block = "y" * 5000
+    result = chunk_messages([big_block], max_len=4096)
+    assert result == [big_block]

--- a/tests/unit/test_telegram_handlers.py
+++ b/tests/unit/test_telegram_handlers.py
@@ -1,0 +1,170 @@
+"""Tests for /unread, /analyze, /inbox handlers in app/telegram/handlers.py."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.telegram import handlers
+
+
+@pytest.fixture
+def authorized_update(monkeypatch):
+    """Authorized Update with an AsyncMock-backed reply_text and DB upsert stubbed."""
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+    update = MagicMock()
+    update.effective_chat.id = 42
+    update.message.reply_text = AsyncMock()
+    return update
+
+
+def _all_reply_texts(update) -> str:
+    """Concatenate every text passed to reply_text across all calls."""
+    return "\n".join(call.args[0] for call in update.message.reply_text.await_args_list)
+
+
+@pytest.mark.asyncio
+async def test_unread_replies_with_numbered_list(monkeypatch, authorized_update):
+    monkeypatch.setattr(
+        handlers,
+        "gmail_fetch_recent",
+        lambda max_results, unread_only: [
+            {"sender": "alice@example.com", "subject": "Hi", "snippet": "hello"},
+            {"sender": "bob@example.com", "subject": "Lunch?", "snippet": "tomorrow?"},
+        ],
+    )
+    await handlers.unread(authorized_update, None)
+    text = _all_reply_texts(authorized_update)
+    assert "*1\\.*" in text
+    assert "*2\\.*" in text
+    assert "alice@example\\.com" in text
+    assert "bob@example\\.com" in text
+
+
+@pytest.mark.asyncio
+async def test_unread_replies_empty_message_when_no_unread(monkeypatch, authorized_update):
+    monkeypatch.setattr(handlers, "gmail_fetch_recent", lambda max_results, unread_only: [])
+    await handlers.unread(authorized_update, None)
+    authorized_update.message.reply_text.assert_awaited_once_with("No unread emails.")
+
+
+@pytest.mark.asyncio
+async def test_unread_reports_gmail_error(monkeypatch, authorized_update):
+    def raise_runtime(**_):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(handlers, "gmail_fetch_recent", raise_runtime)
+    await handlers.unread(authorized_update, None)
+    text = _all_reply_texts(authorized_update)
+    assert "Gmail error" in text
+    assert "boom" in text
+
+
+@pytest.mark.asyncio
+async def test_analyze_runs_claude_and_persists(monkeypatch, authorized_update):
+    pending = [
+        {"gmail_message_id": "g1", "sender": "alice@example.com", "subject": "Hi", "body": "x"},
+        {"gmail_message_id": "g2", "sender": "bob@example.com", "subject": "Re", "body": "y"},
+    ]
+    monkeypatch.setattr(handlers.db, "get_unprocessed_emails", lambda: pending)
+    monkeypatch.setattr(
+        handlers,
+        "analyze_email",
+        lambda email: {
+            "summary": f"sum {email['gmail_message_id']}",
+            "category": "Work",
+            "urgency_score": 7,
+        },
+    )
+    update_calls: list[tuple] = []
+    monkeypatch.setattr(
+        handlers.db,
+        "update_analysis",
+        lambda gid, analysis: update_calls.append((gid, analysis)),
+    )
+
+    await handlers.analyze(authorized_update, None)
+
+    assert len(update_calls) == 2
+    assert {c[0] for c in update_calls} == {"g1", "g2"}
+    text = _all_reply_texts(authorized_update)
+    assert "alice@example\\.com" in text
+    assert "*Category:* Work" in text
+
+
+@pytest.mark.asyncio
+async def test_analyze_replies_empty_when_nothing_pending(monkeypatch, authorized_update):
+    monkeypatch.setattr(handlers.db, "get_unprocessed_emails", list)
+    await handlers.analyze(authorized_update, None)
+    authorized_update.message.reply_text.assert_awaited_once_with("No emails to analyze.")
+
+
+@pytest.mark.asyncio
+async def test_analyze_adds_warning_block_on_claude_failure(monkeypatch, authorized_update):
+    monkeypatch.setattr(
+        handlers.db,
+        "get_unprocessed_emails",
+        lambda: [{"gmail_message_id": "g1", "sender": "alice@example.com"}],
+    )
+    monkeypatch.setattr(handlers, "analyze_email", lambda _: None)
+    monkeypatch.setattr(handlers.db, "update_analysis", lambda *_: None)
+    await handlers.analyze(authorized_update, None)
+    text = _all_reply_texts(authorized_update)
+    assert "⚠️" in text
+    assert "analysis failed" in text
+
+
+@pytest.mark.asyncio
+async def test_inbox_lists_analyzed_rows(monkeypatch, authorized_update):
+    rows = [
+        {
+            "sender": "alice@example.com",
+            "subject": "Done",
+            "ai_summary": "All set.",
+            "urgency_score": 9,
+            "processed_at": "2026-04-30T10:00:00",
+        },
+        {"sender": "skip@example.com", "subject": "ignore", "processed_at": None},
+        {
+            "sender": "bob@example.com",
+            "subject": "Pending",
+            "ai_summary": "Maybe.",
+            "urgency_score": 3,
+            "processed_at": "2026-04-30T11:00:00",
+        },
+    ]
+    monkeypatch.setattr(handlers.db, "get_recent_emails", lambda limit: rows)
+    await handlers.inbox(authorized_update, None)
+    text = _all_reply_texts(authorized_update)
+    assert "alice@example\\.com" in text
+    assert "bob@example\\.com" in text
+    assert "skip@example\\.com" not in text
+    assert "🔴" in text
+    assert "🟢" in text
+
+
+@pytest.mark.asyncio
+async def test_inbox_replies_empty_when_none_analyzed(monkeypatch, authorized_update):
+    monkeypatch.setattr(handlers.db, "get_recent_emails", lambda limit: [])
+    await handlers.inbox(authorized_update, None)
+    authorized_update.message.reply_text.assert_awaited_once_with("No analyzed emails yet.")
+
+
+@pytest.mark.asyncio
+async def test_unread_drops_unauthorized(monkeypatch):
+    """The @authorized_only guard still applies to the new handlers."""
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    fetch_called = False
+
+    def fetch(**_):
+        nonlocal fetch_called
+        fetch_called = True
+        return []
+
+    monkeypatch.setattr(handlers, "gmail_fetch_recent", fetch)
+    update = MagicMock()
+    update.effective_chat.id = 99
+    update.message.reply_text = AsyncMock()
+    await handlers.unread(update, None)
+    assert fetch_called is False
+    update.message.reply_text.assert_not_awaited()


### PR DESCRIPTION
Closes #15

## Summary
- Wraps the existing Gmail fetch / Claude analyzer / DB pipelines as authorized Telegram commands so the user can drive the inbox entirely from chat (no more curl-ing the REST API)
- New `app/telegram/formatting.py` owns all MarkdownV2 escaping and 4096-char message chunking, keeping the handlers thin
- `/analyze` persists each Claude result via `db.update_analysis` so subsequent `/inbox` calls reflect the new rows; failed analyses get a ⚠️ warning block instead of taking the whole command down

## Changes
- `app/telegram/formatting.py` — `escape_markdown_v2`, `format_unread_entry`, `format_analysis_entry`, `format_inbox_entry`, `chunk_messages`, plus a `_priority_emoji` helper (🔴 9-10 / 🟡 5-8 / 🟢 1-4 / ⚪ unknown)
- `app/telegram/handlers.py` — added `unread`, `analyze`, `inbox` async handlers, all `@authorized_only`; `_send_chunks` helper centralizes empty-path messaging + MarkdownV2 dispatch
- `tests/unit/test_telegram_formatting.py` — 19 tests covering escaping, all 3 renderers, priority mapping, and chunking edge cases
- `tests/unit/test_telegram_handlers.py` — 9 tests covering happy + empty + error paths for each command, plus a guard test that the auth decorator is still applied

## Test Plan
- [x] `pytest tests/ --cov=app` passes (62 tests, 94.14% coverage)
- [x] `black app/ tests/` clean
- [x] `flake8 app/ tests/` clean
- [x] Manual end-to-end from Telegram: pre-fetched 5 emails via `POST /emails/fetch`, then ran `/unread` (got numbered list), `/analyze` (got 5 analysis blocks + DB persisted), `/inbox` (got the 5 with priority emojis)

## Acceptance Criteria from #15
- [x] `/unread` calls `get_recent_emails(unread_only=True)` and replies with a numbered list (sender / subject / snippet)
- [x] `/analyze` runs Claude on every unprocessed DB email and replies with category / urgency / summary per email
- [x] `/inbox` reads analyzed DB rows with priority emoji indicators
- [x] Responses >4096 chars split across multiple messages without breaking mid-record
- [x] All MarkdownV2 reserved chars escaped in user-supplied fields; no `can't parse entities` errors observed in manual e2e
- [x] Empty-result paths reply with friendly plain-text messages
- [x] All three handlers wrapped with `@authorized_only` (covered by `test_unread_drops_unauthorized`)
- [x] Type hints + docstrings on all public functions
- [x] Coverage ≥80% (94.14% achieved)
- [x] black + flake8 clean