### PR TITLE
test: add integration suite scaffold + shared fixtures + testing docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,11 @@ app/
     bot.py             # Application singleton + lifecycle helpers
     handlers.py        # Command handlers + @authorized_only decorator
     formatting.py      # MarkdownV2 escaping + 4096-char chunking
-tests/unit/            # All tests live here; no integration/e2e dirs yet
+tests/
+  conftest.py          # Shared fixtures: temp_db, sample_emails, authorized_update, mock_anthropic_response
+  unit/                # Default suite — fast, mocked, runs on every PR
+  integration/         # Opt-in real-API suite, marked @pytest.mark.integration
+  fixtures/            # Canonical mock data (sample_emails.json, ...)
 docs/                  # PRD, PROGRESS, GITHUB_WORKFLOW, templates
 .claude/skills/        # Project-specific Claude Code skills (see below)
 .claude/plans/         # Multi-story implementation plans
@@ -60,6 +64,38 @@ Full conventions live in `docs/GITHUB_WORKFLOW.md`. Don't bypass: skipping `Clos
 - **flake8** clean.
 - **Coverage ≥80%** — `pyproject.toml` has `fail_under = 80`. Live-network paths (OAuth, real Gmail/Telegram I/O) are excluded via `# pragma: no cover` and the `omit` list.
 - **No comments on what the code does.** Only add a comment when the *why* is non-obvious (hidden constraint, workaround, surprising invariant).
+
+## Testing
+
+Two suites, separated by marker:
+
+- **Unit tests** (`tests/unit/`) — default. Fast, no network, all external services mocked. Run on every PR via CI. **Coverage gate: ≥80%** (set in `pyproject.toml`).
+- **Integration tests** (`tests/integration/`) — opt-in, marked `@pytest.mark.integration`, hit real Gmail / Claude. Excluded from default `pytest` runs by `addopts = ["-m", "not integration"]`. Each test self-skips when its prerequisites (e.g. `token.pickle`, `ANTHROPIC_API_KEY`) are missing.
+
+```bash
+# Default suite (unit only) — what CI runs
+.venv/Scripts/pytest tests/ --cov=app
+
+# Integration suite (real APIs, costs money on Claude calls)
+.venv/Scripts/pytest -m integration tests/integration/
+
+# Both
+.venv/Scripts/pytest tests/ -m "" --cov=app
+```
+
+### When to write what
+
+- **New module or non-trivial function** → unit tests in `tests/unit/test_<module>.py`. Mock external calls with the patterns documented in "Test Gmail / Claude / Telegram integration" below.
+- **New API boundary** (new external service, new endpoint that crosses one) → add a single integration test that exercises the live path. Mark `@pytest.mark.integration`. Use `pytest.mark.skipif` so it self-skips without credentials.
+- **Bug fixes** → add a unit test that fails before the fix and passes after. Don't add an integration test unless the bug was at an API boundary.
+- **Pure refactors / renames / docs** → no new tests required; existing suite must still pass.
+
+### Shared fixtures (in `tests/conftest.py`)
+
+- `temp_db` (autouse) — fresh tempfile-backed SQLite per test, schema initialized. Already wired everywhere.
+- `sample_emails` — list of canonical mock emails matching `service.parse_email()` shape; loaded from `tests/fixtures/sample_emails.json`.
+- `authorized_update` — `MagicMock` Telegram Update from chat_id=42 with `reply_text` as `AsyncMock`; auth env var pre-set.
+- `mock_anthropic_response(payload: dict)` — factory that returns a stub Anthropic client whose `messages.create` returns `payload` as JSON. Wire with `monkeypatch.setattr("app.ai.analyzer._get_client", lambda: stub)`.
 
 ## Conventions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,10 @@ target-version = ["py310", "py311", "py312"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
-addopts = "-v --tb=short"
+addopts = ["-v", "--tb=short", "-m", "not integration"]
+markers = [
+    "integration: opt-in tests that hit real APIs (Gmail, Claude). Run with `pytest -m integration`. Excluded by default.",
+]
 
 [tool.coverage.run]
 source = ["app"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,15 @@
+"""Shared pytest fixtures for the ai-email-copilot test suite."""
+
+import importlib
+import json
 import os
 import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
 @pytest.fixture(autouse=True)
@@ -11,8 +19,7 @@ def temp_db(monkeypatch):
     os.close(fd)
     monkeypatch.setenv("DATABASE_PATH", path)
 
-    # Reload the db module so it picks up the new DATABASE_PATH
-    import importlib
+    # Reload the db module so it picks up the new DATABASE_PATH at import time
     from app.database import db as db_module
 
     importlib.reload(db_module)
@@ -21,3 +28,45 @@ def temp_db(monkeypatch):
     yield path
 
     os.unlink(path)
+
+
+@pytest.fixture
+def sample_emails() -> list[dict]:
+    """Canonical mock emails matching service.parse_email() output shape."""
+    with open(FIXTURES_DIR / "sample_emails.json", encoding="utf-8") as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def authorized_update(monkeypatch):
+    """A MagicMock Update from the authorized chat with reply_text as AsyncMock."""
+    from app.database import db
+    from app.telegram import handlers
+
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+    monkeypatch.setattr(db, "get_or_create_telegram_user", lambda _: {})
+    update = MagicMock()
+    update.effective_chat.id = 42
+    update.message.reply_text = AsyncMock()
+    return update
+
+
+@pytest.fixture
+def mock_anthropic_response():
+    """Factory: build a stubbed Anthropic client whose messages.create returns `payload`.
+
+    Usage:
+        def test_something(monkeypatch, mock_anthropic_response):
+            stub = mock_anthropic_response({"summary": "ok", "category": "Work"})
+            monkeypatch.setattr("app.ai.analyzer._get_client", lambda: stub)
+    """
+
+    def _build(payload: dict):
+        client = MagicMock()
+        message = MagicMock()
+        message.content = [MagicMock(text=json.dumps(payload))]
+        client.messages.create.return_value = message
+        return client
+
+    return _build

--- a/tests/fixtures/sample_emails.json
+++ b/tests/fixtures/sample_emails.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "msg_001",
+    "thread_id": "thread_001",
+    "sender": "alice@example.com",
+    "subject": "Q2 planning sync",
+    "date": "2026-04-15T09:00:00Z",
+    "snippet": "Can we move the planning sync to Thursday?",
+    "body": "Hi,\n\nCan we move the Q2 planning sync to Thursday at 2pm? I have a conflict on Wednesday.\n\nThanks,\nAlice"
+  },
+  {
+    "id": "msg_002",
+    "thread_id": "thread_002",
+    "sender": "newsletter@medium.com",
+    "subject": "This week in AI",
+    "date": "2026-04-16T07:30:00Z",
+    "snippet": "Top stories from the AI community this week...",
+    "body": "Top stories from the AI community this week. Click to read more."
+  },
+  {
+    "id": "msg_003",
+    "thread_id": "thread_003",
+    "sender": "boss@corp.com",
+    "subject": "URGENT: client escalation",
+    "date": "2026-04-17T08:00:00Z",
+    "snippet": "Need your eyes on the Acme account before EOD.",
+    "body": "Need your eyes on the Acme account before EOD. They're threatening to churn. Call me when you can."
+  },
+  {
+    "id": "msg_004",
+    "thread_id": "thread_004",
+    "sender": "noreply@github.com",
+    "subject": "[ai-email-copilot] PR #14 merged",
+    "date": "2026-04-30T18:00:00Z",
+    "snippet": "Your pull request has been merged.",
+    "body": "Your pull request has been merged into main."
+  }
+]

--- a/tests/integration/test_ai_analysis_integration.py
+++ b/tests/integration/test_ai_analysis_integration.py
@@ -1,0 +1,38 @@
+"""Integration tests for Claude email analysis.
+
+Run with: pytest -m integration tests/integration/test_ai_analysis_integration.py
+
+These tests cost money — every run hits the real Anthropic API. Keep
+the test count low and the inputs small.
+"""
+
+import os
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.getenv("ANTHROPIC_API_KEY"),
+        reason="Requires ANTHROPIC_API_KEY env var",
+    ),
+]
+
+VALID_CATEGORIES = {"Work", "Personal", "Newsletter", "Finance", "Travel", "Shopping", "Other"}
+VALID_SENTIMENTS = {"Urgent", "Casual", "Formal"}
+VALID_ACTIONS = {"Reply", "Schedule", "Read", "Archive", "Flag"}
+
+
+def test_analyze_returns_well_shaped_dict(sample_emails):
+    """A real Claude call returns the schema documented in analyzer.ANALYSIS_PROMPT."""
+    from app.ai.analyzer import analyze_email
+
+    result = analyze_email(sample_emails[0])
+
+    assert result is not None, "Claude returned None — check API key / quota"
+    assert isinstance(result.get("summary"), str) and result["summary"]
+    assert result.get("category") in VALID_CATEGORIES
+    assert result.get("sentiment") in VALID_SENTIMENTS
+    assert result.get("action_required") in VALID_ACTIONS
+    assert isinstance(result.get("urgency_score"), int)
+    assert 1 <= result["urgency_score"] <= 10

--- a/tests/integration/test_email_fetching_integration.py
+++ b/tests/integration/test_email_fetching_integration.py
@@ -1,0 +1,28 @@
+"""Integration tests for fetching real emails from Gmail.
+
+Run with: pytest -m integration tests/integration/test_email_fetching_integration.py
+"""
+
+import os
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.path.exists("token.pickle"),
+        reason="Requires authenticated token.pickle",
+    ),
+]
+
+
+def test_fetch_recent_returns_parsed_emails():
+    """Live Gmail call returns a list of parsed-email dicts with the expected keys."""
+    from app.gmail.service import get_recent_emails
+
+    emails = get_recent_emails(max_results=3, unread_only=False)
+    assert isinstance(emails, list)
+    if not emails:
+        pytest.skip("Inbox empty — nothing to assert on")
+    for email in emails:
+        assert {"id", "thread_id", "sender", "subject", "date", "snippet", "body"} <= email.keys()

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -1,0 +1,52 @@
+"""End-to-end integration test: fetch -> analyze -> store -> retrieve.
+
+Run with: pytest -m integration tests/integration/test_end_to_end.py
+
+Requires both Gmail OAuth (token.pickle) and ANTHROPIC_API_KEY. Costs
+money on every run because of the live Claude calls.
+"""
+
+import os
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not (os.path.exists("token.pickle") and os.getenv("ANTHROPIC_API_KEY")),
+        reason="Requires token.pickle + ANTHROPIC_API_KEY",
+    ),
+]
+
+
+def test_fetch_analyze_persist_pipeline(temp_db):
+    """Pull a few real emails, run them through Claude, persist results, read back."""
+    from app.ai.analyzer import analyze_email
+    from app.database import db
+    from app.gmail.service import get_recent_emails
+
+    emails = get_recent_emails(max_results=2, unread_only=False)
+    if not emails:
+        pytest.skip("Inbox empty — nothing to analyze")
+
+    for email in emails:
+        db.insert_email(email)
+
+    pending = db.get_unprocessed_emails()
+    assert len(pending) == len(emails)
+
+    analyzed_count = 0
+    for email in pending:
+        analysis = analyze_email(email)
+        if analysis:
+            db.update_analysis(email["gmail_message_id"], analysis)
+            analyzed_count += 1
+
+    assert analyzed_count >= 1, "Every Claude call failed — check API key / quota"
+
+    rows = db.get_recent_emails(limit=10)
+    persisted = [r for r in rows if r.get("processed_at")]
+    assert len(persisted) == analyzed_count
+    for row in persisted:
+        assert row["ai_summary"]
+        assert row["category"]

--- a/tests/integration/test_gmail_auth_integration.py
+++ b/tests/integration/test_gmail_auth_integration.py
@@ -1,0 +1,36 @@
+"""Integration tests for Gmail OAuth flow.
+
+These tests hit real Google OAuth and require a valid `token.pickle` (or
+will trigger a browser-based consent flow). Run explicitly with:
+
+    pytest -m integration tests/integration/test_gmail_auth_integration.py
+"""
+
+import os
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.path.exists("credentials.json"),
+        reason="Requires credentials.json from Google Cloud Console",
+    ),
+]
+
+
+def test_get_credentials_returns_valid_creds():
+    """Calling get_credentials() returns an object with .valid=True after auth."""
+    from app.gmail.auth import get_credentials
+
+    creds = get_credentials()
+    assert creds is not None
+    assert creds.valid is True
+
+
+def test_can_build_gmail_service():
+    """The credentials are usable for instantiating a Gmail API client."""
+    from app.gmail.service import get_email_service
+
+    service = get_email_service()
+    assert service is not None


### PR DESCRIPTION
## Summary
- Splits the test suite into a **default unit suite** (mocked, runs in CI) and an **opt-in integration suite** (real Gmail/Claude, marked `@pytest.mark.integration`, excluded by default via `pyproject.toml` addopts)
- Adds shared fixtures to `tests/conftest.py` so future tests stop redefining the same `MagicMock`/`AsyncMock` boilerplate
- Documents the testing posture in `CLAUDE.md` so future Claude Code sessions don't try to recreate this wheel

## Why
Setting up the testing framework before Story C (reply flow) lands so the new state-machine handlers and reply-generator can be tested with the same patterns the suite already uses elsewhere. Integration scaffolding gives a clear home for "this exercises a real API" tests without polluting the fast unit run that CI gates on.

## Changes
- `pyproject.toml` — register `integration` marker; default addopts now `["-v", "--tb=short", "-m", "not integration"]` so the integration suite is excluded by default
- `tests/conftest.py` — add `sample_emails`, `authorized_update`, `mock_anthropic_response` alongside the existing autouse `temp_db`
- `tests/fixtures/sample_emails.json` — 4 canonical mock email payloads matching `service.parse_email()` output
- `tests/integration/` — 4 modules: `test_gmail_auth_integration`, `test_email_fetching_integration`, `test_ai_analysis_integration`, `test_end_to_end`. Each self-skips when its prerequisites (`token.pickle`, `ANTHROPIC_API_KEY`, `credentials.json`) are missing
- `CLAUDE.md` — new **Testing** section: markers, when-to-write-what, shared fixture inventory; updated layout diagram to include `tests/conftest.py`, `tests/integration/`, `tests/fixtures/`

## What this PR deliberately does NOT do
- Does not modify CI to run integration tests — they cost money and can be flaky on token expiry. Run them locally before shipping.
- Does not add a `pytest.ini` (would conflict with `pyproject.toml` config that already works)
- Does not pin pytest/pytest-cov versions in `requirements-dev.txt` — the unpinned current versions (pytest 9.0.3) work and pinning to older `8.0.0` would be a regression
- Does not refactor existing `test_telegram_handlers.py` to use the conftest `authorized_update` fixture — that's a follow-up; this PR only adds infrastructure

## Test Plan
- [x] `pytest tests/ --cov=app` — 62 unit tests pass, 5 integration tests deselected, **94.14% coverage** ✅
- [x] `pytest -m integration tests/integration/ --co` — all 5 integration tests collected when explicitly requested
- [x] `black app/ tests/` clean
- [x] `flake8 app/ tests/` clean