### PR TITLE
feat: add push notifications for high-priority emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,8 @@ TELEGRAM_BOT_TOKEN=your_botfather_token
 TELEGRAM_AUTHORIZED_CHAT_ID=your_chat_id
 TELEGRAM_WEBHOOK_URL=https://your-tunnel.example.com/telegram/webhook
 TELEGRAM_WEBHOOK_SECRET=any_random_string
+
+# Push notifications (Story D)
+TELEGRAM_PUSH_ENABLED=true
+TELEGRAM_PUSH_INTERVAL_MINUTES=5
+TELEGRAM_PUSH_THRESHOLD=4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,9 @@ Listed in `.env.example`. Don't commit real values.
 | `TELEGRAM_AUTHORIZED_CHAT_ID` | Your chat ID from @userinfobot |
 | `TELEGRAM_WEBHOOK_URL` | Public HTTPS URL Telegram POSTs to (use cloudflared/ngrok in dev) |
 | `TELEGRAM_WEBHOOK_SECRET` | Random string shared with Telegram for request authentication |
+| `TELEGRAM_PUSH_ENABLED` | `true`/`false` — auto-start the push scheduler on app startup (default `true`) |
+| `TELEGRAM_PUSH_INTERVAL_MINUTES` | Scheduler tick interval, minimum 1 (default `5`) |
+| `TELEGRAM_PUSH_THRESHOLD` | Notify only when `urgency_score >= N` (default `4`) |
 
 `token.pickle` (Gmail OAuth) is generated on first auth and refreshed automatically. If `invalid_grant` errors appear, the refresh token has been revoked (Google revokes tokens for "Testing" apps after ~7 days of inactivity) — delete `token.pickle` and re-run `python -c "from app.gmail.auth import get_credentials; get_credentials()"` to re-auth.
 
@@ -186,7 +189,7 @@ Week 3 pivoted from web UI to Telegram-only on 2026-04-24. Story breakdown:
 
 - ✅ Story A — Telegram bot scaffolding + webhook + single-user auth (PR #14, 2026-04-30)
 - ✅ Story B — Pull commands `/unread`, `/analyze`, `/inbox` (PR #16, 2026-05-01)
-- 🔲 Story C — Draft reply generation + approve-before-send flow
-- 🔲 Story D — Push notifications for high-priority emails
+- ✅ Story C — Draft reply generation + approve-before-send flow (PR #19, 2026-05-05)
+- 🔄 Story D — Push notifications for high-priority emails (in flight on `feature/telegram-push-notifications`)
 
 Detailed plan: `~/.claude/plans/concurrent-napping-crescent.md`.

--- a/app/database/db.py
+++ b/app/database/db.py
@@ -40,6 +40,7 @@ def init_db():
 
             -- Metadata
             processed_at TEXT,
+            notified_at TEXT,
             created_at TEXT DEFAULT (datetime('now'))
         );
 
@@ -104,6 +105,12 @@ def init_db():
     existing_cols = {r["name"] for r in conn.execute("PRAGMA table_info(draft_replies)").fetchall()}
     if "status" not in existing_cols:
         conn.execute("ALTER TABLE draft_replies ADD COLUMN status TEXT NOT NULL DEFAULT 'pending'")
+        conn.commit()
+
+    # Backfill emails.notified_at for DBs created before Story D.
+    email_cols = {r["name"] for r in conn.execute("PRAGMA table_info(emails)").fetchall()}
+    if "notified_at" not in email_cols:
+        conn.execute("ALTER TABLE emails ADD COLUMN notified_at TEXT")
         conn.commit()
 
     conn.close()
@@ -196,6 +203,50 @@ def get_unprocessed_emails() -> list[dict]:
     try:
         rows = conn.execute("SELECT * FROM emails WHERE processed_at IS NULL").fetchall()
         return [dict(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def get_high_priority_unnotified(threshold: int) -> list[dict]:
+    """Analyzed emails with urgency >= threshold that haven't been notified yet."""
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            """SELECT * FROM emails
+               WHERE processed_at IS NOT NULL
+                 AND notified_at IS NULL
+                 AND urgency_score IS NOT NULL
+                 AND urgency_score >= ?
+               ORDER BY urgency_score DESC, received_date DESC""",
+            (threshold,),
+        ).fetchall()
+        return [dict(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def mark_email_notified(gmail_message_id: str) -> None:
+    """Stamp notified_at on an email so the push job won't notify again."""
+    conn = get_connection()
+    try:
+        conn.execute(
+            "UPDATE emails SET notified_at = ? WHERE gmail_message_id = ?",
+            (datetime.now().isoformat(), gmail_message_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def mark_email_done(email_row_id: int) -> None:
+    """Mark an email archived + read (used by the Mark Done button on a notification)."""
+    conn = get_connection()
+    try:
+        conn.execute(
+            "UPDATE emails SET is_archived = 1, is_read = 1 WHERE id = ?",
+            (email_row_id,),
+        )
+        conn.commit()
     finally:
         conn.close()
 

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from app.gmail.service import get_recent_emails  # noqa: E402
 from app.ai.analyzer import analyze_email  # noqa: E402
 from app.database import db  # noqa: E402
 from app.telegram import bot as telegram_bot  # noqa: E402
+from app.telegram import push as telegram_push  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -32,9 +33,15 @@ async def startup():
     await application.bot.set_webhook(url=webhook_url, secret_token=secret_token)
     logger.info("Telegram webhook registered at %s", webhook_url)
 
+    if telegram_push.is_enabled_at_boot():
+        interval = int(os.getenv("TELEGRAM_PUSH_INTERVAL_MINUTES", "5"))
+        threshold = int(os.getenv("TELEGRAM_PUSH_THRESHOLD", "4"))
+        telegram_push.start(application, interval_minutes=interval, threshold=threshold)
+
 
 @app.on_event("shutdown")
 async def shutdown():
+    telegram_push.stop()
     await telegram_bot.shutdown()
 
 

--- a/app/telegram/formatting.py
+++ b/app/telegram/formatting.py
@@ -88,6 +88,24 @@ def format_drafts_message(email: dict, drafts: list[dict]) -> str:
     return "".join(sections) if len(sections) == 1 else "\n".join(sections)
 
 
+def format_notification(row: dict) -> str:
+    """MarkdownV2 push-notification block: sender, subject, category, urgency, summary."""
+    sender = escape_markdown_v2(row.get("sender") or "Unknown sender")
+    subject = escape_markdown_v2(row.get("subject") or "(no subject)")
+    category = escape_markdown_v2(row.get("category") or "Unknown")
+    urgency = row.get("urgency_score")
+    urgency_str = escape_markdown_v2(f"{urgency}/10" if urgency is not None else "n/a")
+    summary = escape_markdown_v2(row.get("ai_summary") or "")
+    emoji = _priority_emoji(urgency)
+    return (
+        f"{emoji} *Priority email*\n"
+        f"*From:* {sender}\n"
+        f"*Subject:* {subject}\n"
+        f"*Category:* {category} \\| *Urgency:* {urgency_str}\n"
+        f"{summary}"
+    )
+
+
 def chunk_messages(blocks: list[str], max_len: int = TELEGRAM_MAX_MESSAGE_LEN) -> list[str]:
     """Pack blocks into messages of at most max_len characters.
 

--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -13,6 +13,7 @@ from app.ai.reply_generator import generate_replies, regenerate_one
 from app.database import db
 from app.gmail.service import get_recent_emails as gmail_fetch_recent
 from app.gmail.service import send_reply as gmail_send_reply
+from app.telegram import push as telegram_push
 from app.telegram.conversations import WAITING_FOR_TEXT, build_edit_handler
 from app.telegram.formatting import (
     chunk_messages,
@@ -35,6 +36,8 @@ WELCOME = (
     "/analyze - run AI analysis on unprocessed emails\n"
     "/inbox - show last analyzed emails\n"
     "/reply <id> - draft a reply to an email\n"
+    "/pause - stop push notifications\n"
+    "/resume - start push notifications\n"
     "/help - show this message"
 )
 
@@ -196,10 +199,10 @@ async def reply_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         )
 
 
-def _parse_callback(data: str) -> tuple[str, int] | None:
-    """Parse `r:<action>:<id>` callback data; return (action, id) or None."""
+def _parse_callback(data: str, prefix: str = "r") -> tuple[str, int] | None:
+    """Parse `<prefix>:<action>:<id>` callback data; return (action, id) or None."""
     parts = data.split(":")
-    if len(parts) != 3 or parts[0] != "r" or not parts[2].isdigit():
+    if len(parts) != 3 or parts[0] != prefix or not parts[2].isdigit():
         return None
     return parts[1], int(parts[2])
 
@@ -325,6 +328,53 @@ async def cb_regenerate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     )
 
 
+@authorized_only
+async def cb_notify_reply(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Notification → ✍ Generate Reply: delegate to the Story C /reply flow."""
+    query = update.callback_query
+    await query.answer()
+    parsed = _parse_callback(query.data or "", prefix="n")
+    if parsed is None or parsed[0] != "reply":
+        return
+    _, email_row_id = parsed
+    context.args = [str(email_row_id)]
+    # reply_command reads update.message.reply_text — for callbacks we route
+    # through update.effective_chat instead by patching message onto the update.
+    update.message = query.message
+    await reply_command(update, context)
+
+
+@authorized_only
+async def cb_notify_done(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Notification → ✅ Mark Done: archive+read in DB and edit the message."""
+    query = update.callback_query
+    await query.answer()
+    parsed = _parse_callback(query.data or "", prefix="n")
+    if parsed is None or parsed[0] != "done":
+        return
+    _, email_row_id = parsed
+    db.mark_email_done(email_row_id)
+    try:
+        await query.edit_message_text("✅ Done.")
+    except Exception:  # noqa: BLE001 — non-fatal if message can't be edited
+        logger.exception("Failed to edit notification message for email=%s", email_row_id)
+        await update.effective_chat.send_message("✅ Done.")
+
+
+@authorized_only
+async def pause_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Stop the push scheduler."""
+    telegram_push.pause()
+    await update.message.reply_text("🔕 Notifications paused.")
+
+
+@authorized_only
+async def resume_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Resume the push scheduler (or start it if it wasn't running)."""
+    telegram_push.resume()
+    await update.message.reply_text("🔔 Notifications resumed.")
+
+
 def register(application: Application) -> None:
     """Register all command handlers on the given Application."""
     application.add_handler(CommandHandler("start", start))
@@ -333,6 +383,8 @@ def register(application: Application) -> None:
     application.add_handler(CommandHandler("analyze", analyze))
     application.add_handler(CommandHandler("inbox", inbox))
     application.add_handler(CommandHandler("reply", reply_command))
+    application.add_handler(CommandHandler("pause", pause_command))
+    application.add_handler(CommandHandler("resume", resume_command))
 
     # Edit conversation must be registered before the bare CallbackQueryHandlers,
     # otherwise the entry-point pattern is shadowed.
@@ -340,3 +392,5 @@ def register(application: Application) -> None:
     application.add_handler(CallbackQueryHandler(cb_approve, pattern=r"^r:approve:\d+$"))
     application.add_handler(CallbackQueryHandler(cb_skip, pattern=r"^r:skip:\d+$"))
     application.add_handler(CallbackQueryHandler(cb_regenerate, pattern=r"^r:regen:\d+$"))
+    application.add_handler(CallbackQueryHandler(cb_notify_reply, pattern=r"^n:reply:\d+$"))
+    application.add_handler(CallbackQueryHandler(cb_notify_done, pattern=r"^n:done:\d+$"))

--- a/app/telegram/push.py
+++ b/app/telegram/push.py
@@ -1,0 +1,188 @@
+"""Background scheduler that proactively notifies on high-priority emails.
+
+Runs inside the FastAPI event loop via APScheduler. Each tick:
+  1. Pulls unread mail from Gmail (via the existing service wrapper).
+  2. Persists any new rows in SQLite.
+  3. Analyzes everything not yet processed.
+  4. For every analyzed email at or above the threshold whose `notified_at`
+     is NULL, sends a Telegram notification and stamps `notified_at`.
+
+Idempotency lives in the DB: `notified_at` is the gate, so restarts and
+overlapping ticks never double-notify the same row.
+"""
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.constants import ParseMode
+
+from app.ai.analyzer import analyze_email
+from app.database import db
+from app.gmail.service import get_recent_emails as gmail_fetch_recent
+from app.telegram.formatting import chunk_messages, format_notification
+
+if TYPE_CHECKING:
+    from telegram.ext import Application
+
+DEFAULT_INTERVAL_MINUTES = 5
+DEFAULT_THRESHOLD = 4
+DEFAULT_FETCH_BATCH = 20
+
+JOB_ID = "push_notifications"
+
+logger = logging.getLogger(__name__)
+
+_scheduler: AsyncIOScheduler | None = None
+
+
+def _get_scheduler() -> AsyncIOScheduler:
+    """Lazy scheduler so APScheduler doesn't get a loop before FastAPI has one."""
+    global _scheduler
+    if _scheduler is None:
+        _scheduler = AsyncIOScheduler()
+    return _scheduler
+
+
+def _build_keyboard(email_row_id: int) -> InlineKeyboardMarkup:
+    """Inline keyboard attached to every notification."""
+    return InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton("✍ Generate Reply", callback_data=f"n:reply:{email_row_id}"),
+                InlineKeyboardButton("✅ Mark Done", callback_data=f"n:done:{email_row_id}"),
+            ]
+        ]
+    )
+
+
+async def _notify_one(application: "Application", chat_id: int, row: dict) -> bool:
+    """Send a single notification. Returns True iff Telegram accepted it."""
+    body = format_notification(row)
+    keyboard = _build_keyboard(row["id"])
+    try:
+        for chunk in chunk_messages([body]):
+            await application.bot.send_message(
+                chat_id=chat_id,
+                text=chunk,
+                parse_mode=ParseMode.MARKDOWN_V2,
+                reply_markup=keyboard,
+            )
+    except Exception:  # noqa: BLE001 — log + skip; don't stamp so retry happens next tick
+        logger.exception("Telegram send failed for email row=%s", row.get("id"))
+        return False
+    return True
+
+
+async def tick(application: "Application", *, threshold: int) -> int:
+    """Run one push iteration. Returns the number of notifications sent."""
+    chat_id = _authorized_chat_id()
+    if chat_id is None:
+        logger.warning("TELEGRAM_AUTHORIZED_CHAT_ID unset; skipping push tick")
+        return 0
+
+    _ingest_and_analyze()
+
+    candidates = db.get_high_priority_unnotified(threshold)
+    sent = 0
+    for row in candidates:
+        if await _notify_one(application, chat_id, row):
+            db.mark_email_notified(row["gmail_message_id"])
+            sent += 1
+    return sent
+
+
+def _ingest_and_analyze() -> None:
+    """Pull recent unread, persist new rows, analyze the unprocessed."""
+    try:
+        emails = gmail_fetch_recent(max_results=DEFAULT_FETCH_BATCH, unread_only=True)
+    except Exception:  # noqa: BLE001
+        logger.exception("Gmail fetch failed during push tick")
+        return
+
+    for email in emails:
+        db.insert_email(email)
+
+    for pending in db.get_unprocessed_emails():
+        analysis = analyze_email(pending)
+        if analysis:
+            db.update_analysis(pending["gmail_message_id"], analysis)
+
+
+def _authorized_chat_id() -> int | None:
+    raw = os.getenv("TELEGRAM_AUTHORIZED_CHAT_ID")
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def start(
+    application: "Application",
+    *,
+    interval_minutes: int = DEFAULT_INTERVAL_MINUTES,
+    threshold: int = DEFAULT_THRESHOLD,
+) -> None:
+    """Start (or replace) the recurring push job."""
+    scheduler = _get_scheduler()
+    interval_seconds = max(60, int(interval_minutes) * 60)
+    scheduler.add_job(
+        tick,
+        "interval",
+        seconds=interval_seconds,
+        kwargs={"application": application, "threshold": threshold},
+        id=JOB_ID,
+        replace_existing=True,
+        misfire_grace_time=interval_seconds // 2,
+        coalesce=True,
+        max_instances=1,
+    )
+    if not scheduler.running:
+        scheduler.start()
+    logger.info("Push scheduler started (interval=%dm, threshold=%d)", interval_minutes, threshold)
+
+
+def stop() -> None:
+    """Stop the scheduler entirely; safe to call when not running."""
+    global _scheduler
+    if _scheduler and _scheduler.running:
+        _scheduler.shutdown(wait=False)
+    _scheduler = None
+
+
+def pause() -> bool:
+    """Pause without tearing down the scheduler. Returns True iff state changed."""
+    scheduler = _get_scheduler()
+    if not scheduler.running:
+        return False
+    scheduler.pause()
+    return True
+
+
+def resume() -> bool:
+    """Resume a paused scheduler. Returns True iff state changed."""
+    scheduler = _get_scheduler()
+    if not scheduler.running:
+        scheduler.start()
+        return True
+    if scheduler.state == 2:  # STATE_PAUSED
+        scheduler.resume()
+        return True
+    return False
+
+
+def is_running() -> bool:
+    """Whether the scheduler is currently delivering ticks."""
+    if _scheduler is None:
+        return False
+    return _scheduler.running and _scheduler.state != 2  # not paused
+
+
+def is_enabled_at_boot() -> bool:
+    """Whether TELEGRAM_PUSH_ENABLED says we should auto-start on app startup."""
+    raw = os.getenv("TELEGRAM_PUSH_ENABLED", "true").strip().lower()
+    return raw not in ("0", "false", "no", "off")

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pydantic
 python-dateutil
 httpx
 python-telegram-bot>=21.0
+apscheduler>=3.10

--- a/tests/unit/test_push.py
+++ b/tests/unit/test_push.py
@@ -1,0 +1,243 @@
+"""Unit tests for the push scheduler — Telegram + Gmail + Claude all mocked."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.database import db
+from app.telegram import push
+
+
+def _seed_email(
+    gmail_id: str,
+    *,
+    urgency: int | None = None,
+    notified: bool = False,
+    body: str = "x",
+) -> int:
+    """Insert + analyze + (optionally) mark notified. Return sqlite rowid."""
+    rid = db.insert_email(
+        {
+            "id": gmail_id,
+            "thread_id": "t",
+            "sender": "alice@example.com",
+            "subject": "s",
+            "body": body,
+            "snippet": "",
+            "date": "2026-05-01",
+        }
+    )
+    if urgency is not None:
+        db.update_analysis(
+            gmail_id,
+            {
+                "summary": "sum",
+                "category": "Work",
+                "sentiment": "Casual",
+                "action_required": "Reply",
+                "urgency_score": urgency,
+            },
+        )
+    if notified:
+        db.mark_email_notified(gmail_id)
+    return rid
+
+
+def _stub_application() -> MagicMock:
+    """Application object with bot.send_message as an AsyncMock."""
+    app = MagicMock()
+    app.bot.send_message = AsyncMock()
+    return app
+
+
+@pytest.fixture(autouse=True)
+def reset_scheduler():
+    """Tear down the module-level scheduler between tests."""
+    push.stop()
+    yield
+    push.stop()
+
+
+def test_get_high_priority_unnotified_filters_correctly():
+    _seed_email("low", urgency=2)
+    _seed_email("mid", urgency=4)
+    _seed_email("high", urgency=9)
+    _seed_email("done", urgency=10, notified=True)
+
+    rows = db.get_high_priority_unnotified(threshold=4)
+    ids = [r["gmail_message_id"] for r in rows]
+    assert ids == ["high", "mid"]  # ordered by urgency DESC
+
+
+def test_mark_email_notified_stamps_timestamp():
+    _seed_email("g", urgency=8)
+    db.mark_email_notified("g")
+    row = db.get_email_by_gmail_id("g")
+    assert row["notified_at"] is not None
+
+
+def test_mark_email_done_marks_archived_and_read():
+    rid = _seed_email("d", urgency=8)
+    db.mark_email_done(rid)
+    row = db.get_email_by_gmail_id("d")
+    assert row["is_archived"] == 1
+    assert row["is_read"] == 1
+
+
+@pytest.mark.asyncio
+async def test_tick_sends_only_for_high_priority(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    _seed_email("low", urgency=2)
+    _seed_email("hi1", urgency=7)
+    _seed_email("hi2", urgency=9)
+
+    monkeypatch.setattr(push, "_ingest_and_analyze", lambda: None)
+    app = _stub_application()
+    sent = await push.tick(app, threshold=4)
+
+    assert sent == 2
+    # All sent rows should now be marked notified
+    assert db.get_email_by_gmail_id("hi1")["notified_at"] is not None
+    assert db.get_email_by_gmail_id("hi2")["notified_at"] is not None
+    assert db.get_email_by_gmail_id("low")["notified_at"] is None
+    assert app.bot.send_message.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_tick_is_idempotent(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    _seed_email("g", urgency=9)
+    monkeypatch.setattr(push, "_ingest_and_analyze", lambda: None)
+    app = _stub_application()
+
+    first = await push.tick(app, threshold=4)
+    second = await push.tick(app, threshold=4)
+
+    assert first == 1
+    assert second == 0
+    assert app.bot.send_message.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_tick_does_not_stamp_when_send_fails(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    _seed_email("g", urgency=9)
+    monkeypatch.setattr(push, "_ingest_and_analyze", lambda: None)
+
+    app = MagicMock()
+    app.bot.send_message = AsyncMock(side_effect=RuntimeError("network"))
+
+    sent = await push.tick(app, threshold=4)
+
+    assert sent == 0
+    # Critical: notified_at must NOT be set so the next tick retries.
+    assert db.get_email_by_gmail_id("g")["notified_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_tick_skips_when_chat_id_unset(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_AUTHORIZED_CHAT_ID", raising=False)
+    _seed_email("g", urgency=9)
+    monkeypatch.setattr(push, "_ingest_and_analyze", lambda: None)
+    app = _stub_application()
+
+    sent = await push.tick(app, threshold=4)
+    assert sent == 0
+    app.bot.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tick_calls_ingest_and_analyze(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    called = {"n": 0}
+
+    def fake_ingest():
+        called["n"] += 1
+
+    monkeypatch.setattr(push, "_ingest_and_analyze", fake_ingest)
+    app = _stub_application()
+    await push.tick(app, threshold=4)
+    assert called["n"] == 1
+
+
+def test_ingest_and_analyze_persists_and_analyzes(monkeypatch):
+    monkeypatch.setattr(
+        push,
+        "gmail_fetch_recent",
+        lambda **_: [
+            {
+                "id": "ig1",
+                "thread_id": "t",
+                "sender": "alice@example.com",
+                "subject": "s",
+                "body": "b",
+                "snippet": "",
+                "date": "",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        push,
+        "analyze_email",
+        lambda email: {
+            "summary": "ok",
+            "category": "Work",
+            "sentiment": "Casual",
+            "action_required": "Reply",
+            "urgency_score": 6,
+        },
+    )
+
+    push._ingest_and_analyze()
+
+    row = db.get_email_by_gmail_id("ig1")
+    assert row is not None
+    assert row["urgency_score"] == 6
+
+
+def test_ingest_and_analyze_swallows_gmail_failure(monkeypatch):
+    """Gmail outage shouldn't crash the scheduler — log and move on."""
+
+    def boom(**_):
+        raise RuntimeError("gmail down")
+
+    monkeypatch.setattr(push, "gmail_fetch_recent", boom)
+    push._ingest_and_analyze()  # must not raise
+
+
+def test_pause_and_resume_when_not_running():
+    """pause/resume on a stopped scheduler is a no-op (no exceptions)."""
+    assert push.pause() is False
+    assert push.is_running() is False
+
+
+def test_is_enabled_at_boot_defaults_to_true(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_PUSH_ENABLED", raising=False)
+    assert push.is_enabled_at_boot() is True
+
+
+@pytest.mark.parametrize("val", ["false", "0", "no", "OFF"])
+def test_is_enabled_at_boot_false_values(monkeypatch, val):
+    monkeypatch.setenv("TELEGRAM_PUSH_ENABLED", val)
+    assert push.is_enabled_at_boot() is False
+
+
+@pytest.mark.asyncio
+async def test_start_stop_lifecycle():
+    """start/stop should bring the scheduler up + down without raising."""
+    app = _stub_application()
+    push.start(app, interval_minutes=1, threshold=4)
+    assert push.is_running() is True
+    push.stop()
+    assert push.is_running() is False
+
+
+@pytest.mark.asyncio
+async def test_pause_then_resume_round_trip():
+    app = _stub_application()
+    push.start(app, interval_minutes=1, threshold=4)
+    assert push.pause() is True
+    assert push.is_running() is False
+    assert push.resume() is True
+    assert push.is_running() is True
+    push.stop()

--- a/tests/unit/test_telegram_formatting.py
+++ b/tests/unit/test_telegram_formatting.py
@@ -5,6 +5,7 @@ from app.telegram.formatting import (
     escape_markdown_v2,
     format_analysis_entry,
     format_inbox_entry,
+    format_notification,
     format_unread_entry,
 )
 
@@ -126,3 +127,29 @@ def test_chunk_messages_never_splits_mid_block():
     big_block = "y" * 5000
     result = chunk_messages([big_block], max_len=4096)
     assert result == [big_block]
+
+
+def test_format_notification_includes_all_fields():
+    row = {
+        "sender": "alice@example.com",
+        "subject": "Server down!",
+        "category": "Work",
+        "urgency_score": 9,
+        "ai_summary": "Production database is unreachable.",
+    }
+    out = format_notification(row)
+    assert "🔴" in out
+    assert "Priority email" in out
+    assert "alice@example\\.com" in out
+    assert "Server down\\!" in out
+    assert "Work" in out
+    assert "9/10" in out
+    assert "Production database is unreachable\\." in out
+
+
+def test_format_notification_handles_missing_fields():
+    out = format_notification({})
+    assert "Unknown sender" in out
+    assert "\\(no subject\\)" in out  # parens are MarkdownV2-reserved
+    assert "n/a" in out
+    assert "⚪" in out  # urgency=None → grey emoji

--- a/tests/unit/test_telegram_handlers.py
+++ b/tests/unit/test_telegram_handlers.py
@@ -485,6 +485,106 @@ async def test_cb_edit_save_overwrites_then_sends(monkeypatch, authorized_update
 
 
 @pytest.mark.asyncio
+async def test_pause_command_calls_push_pause_and_replies(monkeypatch, authorized_update):
+    pause_calls = {"n": 0}
+
+    def fake_pause():
+        pause_calls["n"] += 1
+        return True
+
+    monkeypatch.setattr(handlers.telegram_push, "pause", fake_pause)
+    await handlers.pause_command(authorized_update, None)
+    assert pause_calls["n"] == 1
+    text = _all_reply_texts(authorized_update)
+    assert "paused" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_pause_command_idempotent_when_already_paused(monkeypatch, authorized_update):
+    monkeypatch.setattr(handlers.telegram_push, "pause", lambda: False)
+    await handlers.pause_command(authorized_update, None)
+    text = _all_reply_texts(authorized_update)
+    assert "paused" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_resume_command_calls_push_resume_and_replies(monkeypatch, authorized_update):
+    resume_calls = {"n": 0}
+
+    def fake_resume():
+        resume_calls["n"] += 1
+        return True
+
+    monkeypatch.setattr(handlers.telegram_push, "resume", fake_resume)
+    await handlers.resume_command(authorized_update, None)
+    assert resume_calls["n"] == 1
+    text = _all_reply_texts(authorized_update)
+    assert "resumed" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_cb_notify_done_marks_archived_and_edits_message(monkeypatch, reply_context):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+
+    done_calls: list[int] = []
+    monkeypatch.setattr(handlers.db, "mark_email_done", lambda rid: done_calls.append(rid))
+
+    update = _make_callback_update("n:done:5")
+    update.callback_query.edit_message_text = AsyncMock()
+    await handlers.cb_notify_done(update, reply_context)
+
+    assert done_calls == [5]
+    update.callback_query.edit_message_text.assert_awaited_once_with("✅ Done.")
+
+
+@pytest.mark.asyncio
+async def test_cb_notify_done_falls_back_when_edit_fails(monkeypatch, reply_context):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+    monkeypatch.setattr(handlers.db, "mark_email_done", lambda _: None)
+
+    update = _make_callback_update("n:done:5")
+    update.callback_query.edit_message_text = AsyncMock(side_effect=RuntimeError("can't edit"))
+    await handlers.cb_notify_done(update, reply_context)
+
+    update.effective_chat.send_message.assert_awaited()
+    msg = update.effective_chat.send_message.await_args_list[-1].args[0]
+    assert "Done" in msg
+
+
+@pytest.mark.asyncio
+async def test_cb_notify_reply_delegates_to_reply_command(monkeypatch, reply_context):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+
+    captured: dict = {}
+
+    async def fake_reply(update, context):
+        captured["args"] = list(context.args)
+        captured["chat_id"] = update.effective_chat.id
+
+    monkeypatch.setattr(handlers, "reply_command", fake_reply)
+
+    update = _make_callback_update("n:reply:7")
+    await handlers.cb_notify_reply(update, reply_context)
+
+    assert captured == {"args": ["7"], "chat_id": 42}
+
+
+@pytest.mark.asyncio
+async def test_cb_notify_done_ignores_malformed_callback(monkeypatch, reply_context):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+    done_calls: list[int] = []
+    monkeypatch.setattr(handlers.db, "mark_email_done", lambda rid: done_calls.append(rid))
+
+    update = _make_callback_update("n:wrong:5")  # action != 'done'
+    await handlers.cb_notify_done(update, reply_context)
+    assert done_calls == []
+
+
+@pytest.mark.asyncio
 async def test_unread_drops_unauthorized(monkeypatch):
     """The @authorized_only guard still applies to the new handlers."""
     monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")


### PR DESCRIPTION
Closes #20

## Summary

Adds proactive push notifications: a background `AsyncIOScheduler` ticks every `TELEGRAM_PUSH_INTERVAL_MINUTES` minutes, ingests + analyzes recent unread mail, and pushes a Telegram message for any email with `urgency_score >= TELEGRAM_PUSH_THRESHOLD`. Each notification has inline ✍ Generate Reply (delegates to Story C `/reply`) and ✅ Mark Done (archives + reads the email and edits the message). `/pause` and `/resume` toggle the scheduler.

This closes out Week 3 — all four Telegram-pivot stories shipped.

## Changes

**Scheduler**
- `app/telegram/push.py` — new module. `start/stop/pause/resume/is_running/is_enabled_at_boot`, plus `tick(application, threshold)` which orchestrates fetch → store → analyze → notify. Idempotency lives in the DB (`notified_at` gates re-notification across restarts and overlapping ticks). Telegram-send failures are logged and *don't* stamp `notified_at`, so the next tick retries.

**Database**
- `app/database/db.py` — `emails.notified_at` column with a defensive `ALTER TABLE` migration mirroring the Story C `status` migration. Helpers: `get_high_priority_unnotified(threshold)` (filtered + sorted DESC), `mark_email_notified(gmail_id)`, `mark_email_done(row_id)`.

**Telegram**
- `app/telegram/handlers.py` — `/pause`, `/resume` commands (idempotent — pausing twice is fine). `cb_notify_reply` injects `args=[email_id]` and re-uses the existing `reply_command` so the Generate Reply button is the Story C flow with one extra hop. `cb_notify_done` archives + reads in DB, then `query.edit_message_text` to keep the chat clean. `_parse_callback` now takes a `prefix` arg so the `n:*` namespace doesn't collide with Story C's `r:*`.
- `app/telegram/formatting.py` — `format_notification` MarkdownV2 renderer: priority emoji, sender, subject, category, urgency, summary.

**Lifecycle**
- `app/main.py` — startup conditionally starts the scheduler (gated by `TELEGRAM_PUSH_ENABLED`); shutdown calls `telegram_push.stop()` so `--reload` cycles don't leak threads.

**Config & docs**
- `requirements.txt` — `apscheduler>=3.10`.
- `.env.example` + `CLAUDE.md` env-var table — `TELEGRAM_PUSH_ENABLED`, `TELEGRAM_PUSH_INTERVAL_MINUTES`, `TELEGRAM_PUSH_THRESHOLD`.

## How to test

```bash
.venv/Scripts/black --check app/ tests/
.venv/Scripts/flake8 app/ tests/
.venv/Scripts/pytest tests/ --cov=app
```

Manual:
```
# 1. Set TELEGRAM_PUSH_INTERVAL_MINUTES=1 in .env for a quick demo.
# 2. Restart the FastAPI server.
# 3. Send yourself a message that Claude will rate urgency >= 4.
# 4. Within ~1 min: bot pushes a notification with two buttons.
# 5. Tap ✍ Generate Reply → 3 drafts appear (Story C flow).
# 6. Tap ✅ Mark Done → message edits to "✅ Done."; row marked archived+read.
# 7. /pause → scheduler stops; no more pushes. /resume → restored.
```

- [x] 18 new unit tests in `tests/unit/test_push.py` (thresholds, idempotency, send-failure, ingest, lifecycle, pause/resume, env-var parsing)
- [x] 9 new tests in `tests/unit/test_telegram_handlers.py` (cb_notify_reply, cb_notify_done happy path + edit-fail fallback, /pause idempotent, /resume, malformed callback)
- [x] 2 new tests in `tests/unit/test_telegram_formatting.py` (format_notification full + sparse)
- [x] DB helpers covered alongside push tests (`get_high_priority_unnotified`, `mark_email_notified`, `mark_email_done`)

## Test coverage

```
Name                            Stmts   Miss  Cover
---------------------------------------------------
app/ai/analyzer.py                 26      3    88%
app/ai/prompts.py                   7      0   100%
app/ai/reply_generator.py          36      1    97%
app/database/db.py                117     10    91%
app/gmail/service.py               48      2    96%
app/models/schemas.py              19      0   100%
app/telegram/conversations.py      14      0   100%
app/telegram/formatting.py         77      1    99%
app/telegram/handlers.py          263     34    87%
app/telegram/push.py              100      6    94%
---------------------------------------------------
TOTAL                             707     57    92%
```

**91.94% overall** (gate: 80%). 131 tests pass, 6 integration tests deselected by default.

## Checklist

- [x] PR title follows Conventional Commits (`feat:`)
- [x] Body links the issue with `Closes #20`
- [x] All public functions have type hints (Python 3.10+ syntax)
- [x] All public functions have a one-line docstring
- [x] No comments restating *what* the code does
- [x] No secrets / credentials committed
- [x] Coverage ≥ 80% on every changed module
- [x] `black --check` and `flake8` pass locally
- [ ] CI green (will verify after push)
- [ ] `docs/PROGRESS.md` updated (will follow merge)
- [ ] `docs/SPRINT_REPORTS.md` updated (will follow Week 3 close)

## Notes for the reviewer

- The scheduler is process-local. If you ever scale beyond one FastAPI worker, you'll get duplicate notifications — but for a single-user copilot on one box that's fine. A follow-up could move state to SQLite (APScheduler has a SQLAlchemyJobStore) so a worker can resume mid-tick.
- The "Generate Reply" callback re-uses `reply_command` by mutating `update.message = query.message`. That's a small hack but lets us avoid duplicating the 30-line drafting workflow. If we add a third entry point we should refactor `reply_command` into a `_handle_reply(chat_id, email_id, message)` core.
- `_parse_callback` was generalized; the existing `r:*` callers still default to `prefix="r"` so no behavioral change for Story C.