### PR TITLE
fix: split init_db into table/migrate/index phases

### DIFF
--- a/app/database/db.py
+++ b/app/database/db.py
@@ -13,8 +13,10 @@ def get_connection():
 
 
 def init_db():
-    """Create all tables if they don't exist."""
+    """Create tables, run column migrations, then create indexes that depend on them."""
     conn = get_connection()
+    # Tables only — indexes that reference migrated columns must run AFTER the
+    # backfill below, otherwise SQLite raises "no such column" on a pre-Story-C DB.
     conn.executescript("""
         CREATE TABLE IF NOT EXISTS emails (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -44,10 +46,6 @@ def init_db():
             created_at TEXT DEFAULT (datetime('now'))
         );
 
-        CREATE INDEX IF NOT EXISTS idx_gmail_id ON emails(gmail_message_id);
-        CREATE INDEX IF NOT EXISTS idx_category ON emails(category);
-        CREATE INDEX IF NOT EXISTS idx_received_date ON emails(received_date);
-
         CREATE TABLE IF NOT EXISTS draft_replies (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             email_id INTEGER NOT NULL,
@@ -59,9 +57,6 @@ def init_db():
             created_at TEXT DEFAULT (datetime('now')),
             FOREIGN KEY (email_id) REFERENCES emails(id)
         );
-
-        CREATE INDEX IF NOT EXISTS idx_draft_email_id ON draft_replies(email_id);
-        CREATE INDEX IF NOT EXISTS idx_draft_status ON draft_replies(status);
 
         CREATE TABLE IF NOT EXISTS calendar_events (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -102,8 +97,8 @@ def init_db():
     """)
 
     # Backfill the draft_replies.status column for DBs created before Story C.
-    existing_cols = {r["name"] for r in conn.execute("PRAGMA table_info(draft_replies)").fetchall()}
-    if "status" not in existing_cols:
+    draft_cols = {r["name"] for r in conn.execute("PRAGMA table_info(draft_replies)").fetchall()}
+    if "status" not in draft_cols:
         conn.execute("ALTER TABLE draft_replies ADD COLUMN status TEXT NOT NULL DEFAULT 'pending'")
         conn.commit()
 
@@ -113,6 +108,14 @@ def init_db():
         conn.execute("ALTER TABLE emails ADD COLUMN notified_at TEXT")
         conn.commit()
 
+    # Indexes — safe now that every referenced column exists.
+    conn.executescript("""
+        CREATE INDEX IF NOT EXISTS idx_gmail_id ON emails(gmail_message_id);
+        CREATE INDEX IF NOT EXISTS idx_category ON emails(category);
+        CREATE INDEX IF NOT EXISTS idx_received_date ON emails(received_date);
+        CREATE INDEX IF NOT EXISTS idx_draft_email_id ON draft_replies(email_id);
+        CREATE INDEX IF NOT EXISTS idx_draft_status ON draft_replies(status);
+    """)
     conn.close()
 
 

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -1,5 +1,10 @@
 """Smoke tests for the database module."""
 
+import importlib
+import os
+import sqlite3
+import tempfile
+
 import pytest
 
 from app.database import db
@@ -196,6 +201,65 @@ def test_get_email_by_row_id_round_trips():
     found = db.get_email_by_row_id(rid)
     assert found["gmail_message_id"] == "d_lookup"
     assert db.get_email_by_row_id(99999) is None
+
+
+def test_init_db_migrates_pre_story_c_schema(monkeypatch):
+    """A DB created before Story C/D (no draft_replies.status, no emails.notified_at)
+    must migrate cleanly when init_db runs again — no 'no such column' error from
+    indexes referencing the new columns.
+    """
+    fd, legacy_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    try:
+        legacy = sqlite3.connect(legacy_path)
+        legacy.executescript("""
+            CREATE TABLE emails (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                gmail_message_id TEXT UNIQUE NOT NULL,
+                thread_id TEXT,
+                sender TEXT NOT NULL,
+                subject TEXT,
+                body TEXT,
+                snippet TEXT,
+                received_date TEXT,
+                ai_summary TEXT,
+                category TEXT,
+                sentiment TEXT,
+                action_required TEXT,
+                urgency_score INTEGER,
+                is_read INTEGER DEFAULT 0,
+                is_archived INTEGER DEFAULT 0,
+                is_starred INTEGER DEFAULT 0,
+                processed_at TEXT,
+                created_at TEXT
+            );
+            CREATE TABLE draft_replies (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                email_id INTEGER NOT NULL,
+                tone TEXT NOT NULL,
+                draft_text TEXT NOT NULL,
+                was_sent INTEGER DEFAULT 0,
+                sent_at TEXT,
+                created_at TEXT
+            );
+            """)
+        legacy.commit()
+        legacy.close()
+
+        monkeypatch.setenv("DATABASE_PATH", legacy_path)
+        reloaded = importlib.reload(db)
+        reloaded.init_db()  # must not raise
+
+        check = reloaded.get_connection()
+        try:
+            cols_emails = {r["name"] for r in check.execute("PRAGMA table_info(emails)")}
+            cols_drafts = {r["name"] for r in check.execute("PRAGMA table_info(draft_replies)")}
+        finally:
+            check.close()
+        assert "notified_at" in cols_emails
+        assert "status" in cols_drafts
+    finally:
+        os.unlink(legacy_path)
 
 
 def test_get_or_create_telegram_user_creates_on_first_call():


### PR DESCRIPTION
Closes #22

## Summary

Fixes the `sqlite3.OperationalError: no such column: status` crash in `init_db()` on local DBs that pre-date Story C. Caught during manual testing of Week 3 features when uvicorn refused to start.

## Root cause

`init_db()` ran `CREATE INDEX IF NOT EXISTS … ON draft_replies(status)` inside the same `executescript` block as the `CREATE TABLE` definitions, *before* the `ALTER TABLE … ADD COLUMN status` migration that follows. On a fresh DB this works — the table is created with `status` already in its schema. On a legacy DB the `CREATE TABLE IF NOT EXISTS` short-circuits, leaving the old schema in place, and the index statement immediately fails with "no such column".

The `temp_db` fixture creates a fresh DB per test, which is why the 131-test CI suite was green.

## Fix

`init_db()` is now split into three explicit phases:
1. `CREATE TABLE IF NOT EXISTS` for every table.
2. `ALTER TABLE` backfills (`draft_replies.status`, `emails.notified_at`).
3. `CREATE INDEX IF NOT EXISTS` — now safe because every referenced column is guaranteed to exist.

A short docstring on `init_db()` documents the ordering constraint so a future reader doesn't merge the index block back into the schema.

## Regression test

`tests/unit/test_db.py::test_init_db_migrates_pre_story_c_schema` builds a legacy DB by hand (no `status`, no `notified_at`), points `DATABASE_PATH` at it, reloads the `db` module, and asserts `init_db()` runs cleanly and adds both columns.

## How to test

```bash
.venv/Scripts/black --check app/ tests/
.venv/Scripts/flake8 app/ tests/
.venv/Scripts/pytest tests/ --cov=app
```

Manual:
```powershell
# Reproduce the crash on main:
git checkout main
.venv\Scripts\uvicorn app.main:app --port 8000   # → sqlite3.OperationalError

# Apply the fix:
git checkout fix/init-db-index-order
.venv\Scripts\uvicorn app.main:app --port 8000   # → starts cleanly
```

- [x] All 132 tests pass (1 new regression test)
- [x] Coverage 92.51% (gate 80%)
- [x] Lint clean

## Test coverage

```
TOTAL   708   53   93%   (was 91.94%)
```

## Checklist

- [x] PR title follows Conventional Commits (`fix:`)
- [x] Body links the issue with `Closes #22`
- [x] All public functions have type hints
- [x] All public functions have a one-line docstring
- [x] No comments restating *what* the code does
- [x] No secrets / credentials committed
- [x] Coverage ≥ 80% on every changed module
- [x] `black --check` and `flake8` pass locally
- [ ] CI green (will verify after push)
- [ ] `docs/PROGRESS.md` updated — N/A, this is a bug fix not a Week-N task

## Notes for the reviewer

- Found by user during manual end-to-end testing — exactly the kind of bug a fresh-DB test fixture can't catch. Future schema-evolution PRs should add a "legacy DB → init_db migrates cleanly" test as a habit.
- No data migration impact: the `ALTER TABLE`s here are additive only. Pre-existing `was_sent` rows still work; the new `status` column defaults to `'pending'` for them, which is semantically correct (they were never approved/sent through the new flow).