### PR TITLE
fix: run push tick I/O in worker threads + quiet transient errors

### DIFF
--- a/app/telegram/push.py
+++ b/app/telegram/push.py
@@ -11,6 +11,7 @@ Idempotency lives in the DB: `notified_at` is the gate, so restarts and
 overlapping ticks never double-notify the same row.
 """
 
+import asyncio
 import logging
 import os
 from typing import TYPE_CHECKING
@@ -77,38 +78,74 @@ async def _notify_one(application: "Application", chat_id: int, row: dict) -> bo
 
 
 async def tick(application: "Application", *, threshold: int) -> int:
-    """Run one push iteration. Returns the number of notifications sent."""
+    """Run one push iteration. Returns the number of notifications sent.
+
+    All blocking I/O (Gmail, Claude, SQLite) runs via `asyncio.to_thread` so the
+    FastAPI event loop stays responsive even when the network stalls.
+    """
     chat_id = _authorized_chat_id()
     if chat_id is None:
         logger.warning("TELEGRAM_AUTHORIZED_CHAT_ID unset; skipping push tick")
         return 0
 
-    _ingest_and_analyze()
+    await _ingest_and_analyze()
 
-    candidates = db.get_high_priority_unnotified(threshold)
+    candidates = await asyncio.to_thread(db.get_high_priority_unnotified, threshold)
     sent = 0
     for row in candidates:
         if await _notify_one(application, chat_id, row):
-            db.mark_email_notified(row["gmail_message_id"])
+            await asyncio.to_thread(db.mark_email_notified, row["gmail_message_id"])
             sent += 1
     return sent
 
 
-def _ingest_and_analyze() -> None:
-    """Pull recent unread, persist new rows, analyze the unprocessed."""
+def _is_transient_network_error(exc: BaseException) -> bool:
+    """Whether `exc` is a known-flaky network condition (DNS, timeout, conn reset).
+
+    `socket.gaierror` and `httplib2.error.ServerNotFoundError` both subclass
+    `OSError`, and `TimeoutError` covers Python's read/connect timeouts.
+    """
+    return isinstance(exc, (TimeoutError, OSError))
+
+
+async def _ingest_and_analyze() -> None:
+    """Pull recent unread, persist new rows, analyze the unprocessed.
+
+    Each external call runs in a worker thread so the loop never blocks. Known
+    transient network failures degrade to a one-line WARNING; truly unexpected
+    errors still log a full traceback for debuggability.
+    """
     try:
-        emails = gmail_fetch_recent(max_results=DEFAULT_FETCH_BATCH, unread_only=True)
-    except Exception:  # noqa: BLE001
-        logger.exception("Gmail fetch failed during push tick")
+        emails = await asyncio.to_thread(
+            gmail_fetch_recent,
+            max_results=DEFAULT_FETCH_BATCH,
+            unread_only=True,
+        )
+    except Exception as exc:  # noqa: BLE001
+        if _is_transient_network_error(exc):
+            logger.warning("Gmail fetch transient error during push tick: %s", exc)
+        else:
+            logger.exception("Gmail fetch failed during push tick")
         return
 
     for email in emails:
-        db.insert_email(email)
+        try:
+            await asyncio.to_thread(db.insert_email, email)
+        except Exception:  # noqa: BLE001
+            logger.exception("DB insert failed for gmail_message_id=%s", email.get("id"))
 
-    for pending in db.get_unprocessed_emails():
-        analysis = analyze_email(pending)
+    pending = await asyncio.to_thread(db.get_unprocessed_emails)
+    for em in pending:
+        try:
+            analysis = await asyncio.to_thread(analyze_email, em)
+        except Exception as exc:  # noqa: BLE001
+            if _is_transient_network_error(exc):
+                logger.warning("Claude transient error analyzing %s: %s", em.get("id"), exc)
+            else:
+                logger.exception("Claude analysis failed for %s", em.get("id"))
+            continue
         if analysis:
-            db.update_analysis(pending["gmail_message_id"], analysis)
+            await asyncio.to_thread(db.update_analysis, em["gmail_message_id"], analysis)
 
 
 def _authorized_chat_id() -> int | None:

--- a/tests/unit/test_push.py
+++ b/tests/unit/test_push.py
@@ -1,5 +1,6 @@
 """Unit tests for the push scheduler — Telegram + Gmail + Claude all mocked."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -50,6 +51,11 @@ def _stub_application() -> MagicMock:
     return app
 
 
+async def _async_noop(*_args, **_kwargs) -> None:
+    """Awaitable no-op — used to monkeypatch the now-async _ingest_and_analyze."""
+    return None
+
+
 @pytest.fixture(autouse=True)
 def reset_scheduler():
     """Tear down the module-level scheduler between tests."""
@@ -91,7 +97,7 @@ async def test_tick_sends_only_for_high_priority(monkeypatch):
     _seed_email("hi1", urgency=7)
     _seed_email("hi2", urgency=9)
 
-    monkeypatch.setattr(push, "_ingest_and_analyze", lambda: None)
+    monkeypatch.setattr(push, "_ingest_and_analyze", _async_noop)
     app = _stub_application()
     sent = await push.tick(app, threshold=4)
 
@@ -107,7 +113,7 @@ async def test_tick_sends_only_for_high_priority(monkeypatch):
 async def test_tick_is_idempotent(monkeypatch):
     monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
     _seed_email("g", urgency=9)
-    monkeypatch.setattr(push, "_ingest_and_analyze", lambda: None)
+    monkeypatch.setattr(push, "_ingest_and_analyze", _async_noop)
     app = _stub_application()
 
     first = await push.tick(app, threshold=4)
@@ -122,7 +128,7 @@ async def test_tick_is_idempotent(monkeypatch):
 async def test_tick_does_not_stamp_when_send_fails(monkeypatch):
     monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
     _seed_email("g", urgency=9)
-    monkeypatch.setattr(push, "_ingest_and_analyze", lambda: None)
+    monkeypatch.setattr(push, "_ingest_and_analyze", _async_noop)
 
     app = MagicMock()
     app.bot.send_message = AsyncMock(side_effect=RuntimeError("network"))
@@ -138,7 +144,7 @@ async def test_tick_does_not_stamp_when_send_fails(monkeypatch):
 async def test_tick_skips_when_chat_id_unset(monkeypatch):
     monkeypatch.delenv("TELEGRAM_AUTHORIZED_CHAT_ID", raising=False)
     _seed_email("g", urgency=9)
-    monkeypatch.setattr(push, "_ingest_and_analyze", lambda: None)
+    monkeypatch.setattr(push, "_ingest_and_analyze", _async_noop)
     app = _stub_application()
 
     sent = await push.tick(app, threshold=4)
@@ -151,7 +157,7 @@ async def test_tick_calls_ingest_and_analyze(monkeypatch):
     monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
     called = {"n": 0}
 
-    def fake_ingest():
+    async def fake_ingest():
         called["n"] += 1
 
     monkeypatch.setattr(push, "_ingest_and_analyze", fake_ingest)
@@ -160,7 +166,8 @@ async def test_tick_calls_ingest_and_analyze(monkeypatch):
     assert called["n"] == 1
 
 
-def test_ingest_and_analyze_persists_and_analyzes(monkeypatch):
+@pytest.mark.asyncio
+async def test_ingest_and_analyze_persists_and_analyzes(monkeypatch):
     monkeypatch.setattr(
         push,
         "gmail_fetch_recent",
@@ -188,21 +195,85 @@ def test_ingest_and_analyze_persists_and_analyzes(monkeypatch):
         },
     )
 
-    push._ingest_and_analyze()
+    await push._ingest_and_analyze()
 
     row = db.get_email_by_gmail_id("ig1")
     assert row is not None
     assert row["urgency_score"] == 6
 
 
-def test_ingest_and_analyze_swallows_gmail_failure(monkeypatch):
+@pytest.mark.asyncio
+async def test_ingest_and_analyze_swallows_gmail_failure(monkeypatch):
     """Gmail outage shouldn't crash the scheduler — log and move on."""
 
     def boom(**_):
         raise RuntimeError("gmail down")
 
     monkeypatch.setattr(push, "gmail_fetch_recent", boom)
-    push._ingest_and_analyze()  # must not raise
+    await push._ingest_and_analyze()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_ingest_and_analyze_logs_warning_on_transient_dns_error(monkeypatch, caplog):
+    """socket.gaierror (subclass of OSError) → one-line warning, no traceback."""
+    import socket
+
+    def gai_fail(**_):
+        raise socket.gaierror(11001, "getaddrinfo failed")
+
+    monkeypatch.setattr(push, "gmail_fetch_recent", gai_fail)
+    inserted: list = []
+    monkeypatch.setattr(push.db, "insert_email", lambda e: inserted.append(e))
+
+    with caplog.at_level("WARNING", logger="app.telegram.push"):
+        await push._ingest_and_analyze()
+
+    assert inserted == []  # nothing fetched → nothing inserted
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert any("transient" in r.getMessage().lower() for r in warnings)
+    # Critical: no exception-level record (those carry full tracebacks).
+    assert not any(r.exc_info for r in caplog.records if r.levelno >= 40)
+
+
+@pytest.mark.asyncio
+async def test_ingest_and_analyze_keeps_traceback_for_unexpected_errors(monkeypatch, caplog):
+    """A non-network error (e.g. ValueError) must still surface a full traceback."""
+
+    def boom(**_):
+        raise ValueError("something else")
+
+    monkeypatch.setattr(push, "gmail_fetch_recent", boom)
+    with caplog.at_level("ERROR", logger="app.telegram.push"):
+        await push._ingest_and_analyze()
+    errors = [r for r in caplog.records if r.levelno >= 40]
+    assert any(r.exc_info for r in errors), "unexpected error must log traceback"
+
+
+@pytest.mark.asyncio
+async def test_tick_does_not_block_event_loop(monkeypatch):
+    """Concurrent task must make progress while a slow Gmail call is in-flight."""
+    import time
+
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+
+    def slow_fetch(**_):
+        time.sleep(0.5)  # synchronous block — must run in a worker thread
+        return []
+
+    monkeypatch.setattr(push, "gmail_fetch_recent", slow_fetch)
+    app = _stub_application()
+
+    parallel_done = asyncio.Event()
+
+    async def parallel():
+        await asyncio.sleep(0.1)
+        parallel_done.set()
+
+    parallel_task = asyncio.create_task(parallel())
+    await push.tick(app, threshold=4)
+
+    assert parallel_done.is_set(), "loop was blocked by sync gmail call"
+    await parallel_task
 
 
 def test_pause_and_resume_when_not_running():


### PR DESCRIPTION
Closes #26

## Summary

Push tick was freezing the FastAPI event loop. Root cause: `tick()` is `async def`, but it called `gmail_fetch_recent` (sync `httplib2`) and `analyze_email` (sync Anthropic SDK) directly inside the coroutine. A single 30-second TCP read timeout would stall every Telegram command in the chat AND cause APScheduler to log `Run time of job "tick" was missed by 0:04:14` because the next 5-minute interval came and went while the previous tick was still blocked.

The transient errors themselves (`socket.gaierror`, `httplib2.error.ServerNotFoundError`, `TimeoutError`) were already caught — but `logger.exception(...)` printed a multi-page stack trace for what's really just "wifi blipped." Console looked broken.

## Fix

**`app/telegram/push.py`**

- `_ingest_and_analyze` is now `async`. Every blocking call (`gmail_fetch_recent`, `analyze_email`, `db.insert_email`, `db.get_unprocessed_emails`, `db.update_analysis`) goes through `asyncio.to_thread`, so the loop is free to handle Telegram traffic during the tick.
- `tick()` does the same for `db.get_high_priority_unnotified` and `db.mark_email_notified`.
- New `_is_transient_network_error(exc)` returns True for `(TimeoutError, OSError)` — both `socket.gaierror` and `httplib2.error.ServerNotFoundError` subclass `OSError`, so this catches the wifi-blip case without swallowing real bugs.
- Logging is split: transient errors → `logger.warning(...)` one-liner; anything else (e.g. `ValueError`, programming bugs) still gets `logger.exception(...)` with full traceback.

## Why this matters

Before: a 30s wifi stall blocked every command for 30s and made APScheduler skip the next tick. With a 5-minute interval and 30-second blocks, the scheduler could miss arbitrarily many ticks during a flaky network period.

After: a 30s wifi stall takes 30s in a worker thread but the event loop continues serving Telegram. The current tick still fails (the network is genuinely down), logs a one-line warning, and the next tick fires on schedule.

## How to test

```bash
.venv/Scripts/black --check app/ tests/
.venv/Scripts/flake8 app/ tests/
.venv/Scripts/pytest tests/ --cov=app
```

Manual repro of the original bug (requires the fix to be reverted to confirm it fails before, passes after):

```
1. TELEGRAM_PUSH_INTERVAL_MINUTES=1 in .env, restart uvicorn.
2. Send /unread — works.
3. Disconnect wifi for ~60s.
4. While wifi is off, send /unread.
5. Reconnect.
6. Observe: with the fix, the bot still answers /unread eventually (no 30s freeze waiting on the push tick); console shows a single "Gmail fetch transient error during push tick" WARNING line.
```

## Test coverage

```
Name                            Stmts   Miss  Cover
---------------------------------------------------
app/ai/analyzer.py                 26      3    88%
app/ai/prompts.py                   7      0   100%
app/ai/reply_generator.py          36      1    97%
app/database/db.py                118      6    95%
app/gmail/service.py               48      2    96%
app/models/schemas.py              19      0   100%
app/telegram/conversations.py      14      0   100%
app/telegram/formatting.py         82      0   100%
app/telegram/handlers.py          290     33    89%
app/telegram/push.py              115     13    89%
---------------------------------------------------
TOTAL                             755     58    92%
```

**92.32% overall** (gate 80%). 141 tests pass, 6 integration deselected. 3 new regression tests:

- `test_ingest_and_analyze_logs_warning_on_transient_dns_error` — `socket.gaierror` logs WARNING with no `exc_info`; nothing inserted into DB.
- `test_ingest_and_analyze_keeps_traceback_for_unexpected_errors` — `ValueError` still produces a full traceback so we don't lose debuggability for real bugs.
- `test_tick_does_not_block_event_loop` — schedules a parallel `asyncio.sleep(0.1)` while a synthetic 500ms blocking `gmail_fetch_recent` is in flight; asserts the parallel task completed (proves the loop wasn't frozen).

## Checklist

- [x] PR title follows Conventional Commits (`fix:`)
- [x] Body links the issue with `Closes #26`
- [x] All public functions have type hints
- [x] All public functions have a one-line docstring
- [x] No comments restating *what* the code does
- [x] No secrets / credentials committed
- [x] Coverage ≥ 80% on every changed module
- [x] `black --check` and `flake8` pass locally
- [ ] CI green (will verify after push)
- [ ] `docs/PROGRESS.md` updated — N/A, this is a bug fix not a Week-N task

## Notes for the reviewer

- Same architectural pattern (`asyncio.to_thread` around sync SDK calls) should also be applied to the foreground command handlers — `/analyze` and `/reply` both invoke Claude/Gmail synchronously. Filing as a follow-up rather than expanding this PR's scope; the push tick is the one that runs unattended every 5 min, so it was the most impactful place to fix first.
- `(TimeoutError, OSError)` is intentionally narrow — it catches network/socket flakiness without masking unexpected exceptions. If we discover other transient classes in the wild (e.g. `httpx.ConnectTimeout`), add them to `_is_transient_network_error`.