### PR TITLE
feat: add GitHub Actions auto-deploy workflow + CI/CD runbook

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,112 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+# Two pushes 30s apart should not race on the instance. cancel-in-progress=false
+# means the second one queues; the first finishes and the bot is restarted twice
+# with no risk of an interleaved git checkout.
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    # OIDC: the runner gets a short-lived JWT it presents to AWS STS in exchange
+    # for temporary credentials. No long-lived AWS_ACCESS_KEY_ID in repo secrets.
+    permissions:
+      id-token: write
+      contents: read
+
+    env:
+      AWS_REGION: eu-west-1
+      HEALTH_URL: https://79-125-102-15.nip.io/health
+
+    steps:
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Send deploy command via SSM
+        id: send
+        env:
+          INSTANCE_ID: ${{ secrets.AWS_INSTANCE_ID }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # One single shell invocation joined with && so any failure aborts the
+          # rest. Pinned to ${SHA} (not `git pull`) so a re-run of an older
+          # workflow run deploys that older commit — supports rollback.
+          DEPLOY_CMD="cd /home/copilot/email-assistant \
+            && sudo -u copilot git fetch origin main \
+            && sudo -u copilot git checkout ${SHA} \
+            && sudo -u copilot .venv/bin/pip install -q -r requirements.txt \
+            && systemctl restart copilot"
+
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids "${INSTANCE_ID}" \
+            --document-name "AWS-RunShellScript" \
+            --comment "github-actions deploy ${SHA}" \
+            --timeout-seconds 300 \
+            --parameters "commands=[\"${DEPLOY_CMD}\"]" \
+            --query "Command.CommandId" \
+            --output text)
+
+          echo "command_id=${COMMAND_ID}" >> "${GITHUB_OUTPUT}"
+          echo "Sent SSM command ${COMMAND_ID} for ${SHA}"
+
+      - name: Wait for SSM command
+        env:
+          INSTANCE_ID: ${{ secrets.AWS_INSTANCE_ID }}
+          COMMAND_ID: ${{ steps.send.outputs.command_id }}
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "${COMMAND_ID}" \
+              --instance-id "${INSTANCE_ID}" \
+              --query Status \
+              --output text 2>/dev/null || echo "Pending")
+            echo "[${i}/30] Status: ${STATUS}"
+            case "${STATUS}" in
+              Success)
+                echo "Deploy command succeeded."
+                exit 0
+                ;;
+              Failed|Cancelled|TimedOut)
+                echo "Deploy command ended in ${STATUS}. stderr from instance:"
+                aws ssm get-command-invocation \
+                  --command-id "${COMMAND_ID}" \
+                  --instance-id "${INSTANCE_ID}" \
+                  --query StandardErrorContent \
+                  --output text
+                exit 1
+                ;;
+            esac
+            sleep 10
+          done
+          echo "Timed out waiting for SSM command"
+          exit 1
+
+      - name: Smoke-check /health
+        run: |
+          set -euo pipefail
+          # uvicorn cold-start on t4g.nano is ~3s; webhook re-registration adds
+          # a few more. 3 attempts at 5s spacing covers that without being slow.
+          for i in 1 2 3; do
+            if curl -fsS --max-time 10 "${HEALTH_URL}"; then
+              echo
+              echo "Health OK on attempt ${i}"
+              exit 0
+            fi
+            echo "Health attempt ${i}/3 failed; retrying in 5s"
+            sleep 5
+          done
+          echo "Health check never returned 200"
+          exit 1

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For production, the bot runs on a single AWS EC2 instance behind Caddy/HTTPS at 
 
 Step-by-step CLI runbook: [`docs/AWS_DEPLOY.md`](docs/AWS_DEPLOY.md). Steady-state cost ~$5/month plus Anthropic API charges. Templates for Caddy + systemd live in [`infra/`](infra/).
 
-CI/CD (auto-deploy on `main` push, monitoring) ships in subsequent stories — see issue tracker.
+**CI/CD**: every push to `main` auto-deploys via [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml) — GitHub OIDC → AWS STS → SSM `send-command` runs `git checkout <sha> && pip install && systemctl restart copilot`, then smoke-checks `/health`. No long-lived AWS keys, no SSH. Rollback is "Re-run all jobs" on a previous successful run. Setup steps in [`docs/AWS_DEPLOY.md`](docs/AWS_DEPLOY.md) under *CI/CD*.
 
 ## Project Structure
 

--- a/docs/AWS_DEPLOY.md
+++ b/docs/AWS_DEPLOY.md
@@ -333,6 +333,139 @@ Once the deploy is live, on your laptop:
 
 ---
 
+## CI/CD: GitHub Actions auto-deploy (W6-B)
+
+Once Story A is live, this section sets up auto-deploy on every push to `main`. The workflow file is `.github/workflows/deploy.yml` — it uses **OIDC** (no long-lived AWS access keys) to assume an IAM role that's allowed to send a deploy command via SSM to the one instance, then smoke-checks `/health` to verify.
+
+### Step CD-1 — Create the GitHub OIDC identity provider in IAM
+
+Run on your **laptop** (one-time per AWS account):
+
+```powershell
+aws iam create-open-id-connect-provider `
+  --url https://token.actions.githubusercontent.com `
+  --client-id-list sts.amazonaws.com `
+  --thumbprint-list 6938fd4d98bab03faadb97b34396831e3780aea1
+```
+
+> The thumbprint is GitHub's well-known cert thumbprint. AWS verifies the OIDC JWT against this; the OIDC token is short-lived (15 min) and per-workflow-run, so even if intercepted there's nothing to steal long-term. AWS now also supports `--thumbprint-list` being optional (auto-fetched), but pinning it is the canonical pattern.
+
+If the provider already exists in your account from another repo, this returns `EntityAlreadyExistsException` — that's fine, skip to CD-2.
+
+### Step CD-2 — Capture the AWS account ID
+
+```powershell
+$ACCOUNT_ID = aws sts get-caller-identity --query Account --output text
+Write-Host "ACCOUNT_ID=$ACCOUNT_ID"
+```
+
+### Step CD-3 — Trust policy (who can assume the role)
+
+Replace `H1shamM/ai-email-copilot` with your actual fork if different. The `:sub` condition restricts assumption to commits on this repo's `main` branch — a fork can't get into your AWS account.
+
+```powershell
+@"
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Federated": "arn:aws:iam::$ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com"
+    },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": {
+        "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+        "token.actions.githubusercontent.com:sub": "repo:H1shamM/ai-email-copilot:ref:refs/heads/main"
+      }
+    }
+  }]
+}
+"@ | Out-File -FilePath trust-policy.json -Encoding ascii
+```
+
+### Step CD-4 — Permission policy (what the role can do)
+
+Scoped to one SSM action on one instance + one document. Anything more is unnecessary.
+
+```powershell
+@"
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DeployViaSSMSendCommand",
+      "Effect": "Allow",
+      "Action": "ssm:SendCommand",
+      "Resource": [
+        "arn:aws:ec2:$($env:AWS_REGION):$($ACCOUNT_ID):instance/$INSTANCE_ID",
+        "arn:aws:ssm:$($env:AWS_REGION)::document/AWS-RunShellScript"
+      ]
+    },
+    {
+      "Sid": "ReadCommandStatus",
+      "Effect": "Allow",
+      "Action": "ssm:GetCommandInvocation",
+      "Resource": "*"
+    }
+  ]
+}
+"@ | Out-File -FilePath deploy-policy.json -Encoding ascii
+```
+
+### Step CD-5 — Create the role and attach the policy
+
+```powershell
+$ROLE_ARN = aws iam create-role `
+  --role-name copilot-github-deploy `
+  --assume-role-policy-document file://trust-policy.json `
+  --description "GitHub Actions deploys to the AI Email Copilot EC2 instance via SSM" `
+  --query "Role.Arn" --output text
+
+aws iam put-role-policy `
+  --role-name copilot-github-deploy `
+  --policy-name copilot-github-deploy-inline `
+  --policy-document file://deploy-policy.json
+
+Write-Host "ROLE_ARN=$ROLE_ARN"
+
+# Clean up local files (the policies are now in IAM)
+Remove-Item trust-policy.json, deploy-policy.json
+```
+
+### Step CD-6 — Add repo secrets
+
+```powershell
+gh secret set AWS_DEPLOY_ROLE_ARN --body "$ROLE_ARN"
+gh secret set AWS_INSTANCE_ID --body "$INSTANCE_ID"
+```
+
+(Or via the GitHub web UI: *Settings → Secrets and variables → Actions → New repository secret*.)
+
+### Step CD-7 — Trigger a deploy
+
+The workflow already exists at `.github/workflows/deploy.yml` after PR for #30 merges. To trigger:
+
+- **Automatic:** any subsequent push to `main` runs it.
+- **Manual:** `gh workflow run deploy.yml` (or the Actions UI's *Run workflow* button).
+
+Watch it: `gh run watch` or the Actions tab. A successful run logs:
+
+```
+Configure AWS credentials via OIDC ... ok
+Send deploy command via SSM ... command_id=...
+Wait for SSM command ... [1/30] Status: Success
+Smoke-check /health ... {"ok":true}
+```
+
+### Step CD-8 — Rollback
+
+GitHub Actions UI → **Actions** tab → pick a previous successful **Deploy** run → **Re-run all jobs**. The re-run inherits that run's `github.sha`, so the deploy script checks out the older commit and restarts the bot. No git surgery on the instance.
+
+If the bad commit is already on `main`, you can also revert via PR (`git revert <sha> && open PR`) — the merge of that revert auto-deploys via the normal workflow.
+
+---
+
 ## Teardown (when you want to stop paying)
 
 ```powershell
@@ -357,6 +490,12 @@ aws iam delete-role --role-name $env:IAM_ROLE_NAME
 # 5. Unregister the Telegram webhook so the bot doesn't keep retrying a dead URL
 $env:TELEGRAM_BOT_TOKEN = "<your bot token>"
 .venv\Scripts\python -c "import asyncio,os; from telegram import Bot; asyncio.run(Bot(os.environ['TELEGRAM_BOT_TOKEN']).delete_webhook())"
+
+# 6. (CI/CD only) Tear down the GitHub Actions deploy role
+aws iam delete-role-policy --role-name copilot-github-deploy --policy-name copilot-github-deploy-inline
+aws iam delete-role --role-name copilot-github-deploy
+# Only delete the OIDC provider if no other repo uses it:
+# aws iam delete-open-id-connect-provider --open-id-connect-provider-arn arn:aws:iam::$ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com
 ```
 
 ---
@@ -372,6 +511,8 @@ $env:TELEGRAM_BOT_TOKEN = "<your bot token>"
 | `journalctl -u copilot` shows `telegram.error.TimedOut` | Cold-start TLS slowness | Already handled by `bot.py`'s 30s `HTTPXRequest` timeout (#25) |
 | Bot misses ticks under network flakiness | Was the synchronous-blocking issue | Already fixed in #27 — push tick uses `asyncio.to_thread` |
 | `journalctl -u copilot` shows `invalid_grant` for Gmail | Google revoked the refresh token (Testing app, ~7 days idle) | Re-run OAuth on laptop, re-bootstrap `token.pickle` per Step 10. Long-term fix: publish the OAuth app or move it to External + Production status |
+| Deploy workflow fails with `Could not assume role` | OIDC trust policy doesn't match the workflow's `:sub` claim | Check the role's trust policy: it must list the exact repo + branch (`repo:OWNER/REPO:ref:refs/heads/main`). A fork or a non-`main` branch can't assume |
+| Deploy workflow fails on `Smoke-check /health` after `SSM command succeeded` | uvicorn started but the app errored at runtime; previous version is gone | `aws ssm start-session --target $INSTANCE_ID` then `journalctl -u copilot -n 200`. To restore the previous good commit, re-run that workflow in the Actions UI |
 
 ---
 


### PR DESCRIPTION
Refs #30 (Week 6 Story B — Track 2 of 2)

## Summary

Adds the GitHub Actions auto-deploy workflow and the CI/CD runbook for AWS-side OIDC + IAM setup. After this merges, you (the operator) follow `docs/AWS_DEPLOY.md` *CI/CD* section to run Track 1 — create the OIDC provider, the role with the trust + permission policies, and add two repo secrets. Issue #30 closes when the first auto-deploy run goes green.

## What's in this PR

### `.github/workflows/deploy.yml`

- `on.push.branches: [main]` plus `workflow_dispatch` so you can trigger from the Actions UI when needed.
- `permissions: { id-token: write, contents: read }` — OIDC. **No long-lived AWS access keys in repo secrets**; the runner exchanges its short-lived JWT for AWS STS credentials at job start.
- `concurrency: deploy-prod` with `cancel-in-progress: false` so two merges 30s apart **queue** instead of racing on the instance (no interleaved `git checkout`).
- Three meaningful steps:
  1. **Configure AWS credentials via OIDC** — `aws-actions/configure-aws-credentials@v4` assumes `${{ secrets.AWS_DEPLOY_ROLE_ARN }}`.
  2. **Send deploy command via SSM** — `aws ssm send-command` runs one shell line joined by `&&`:

     ```bash
     cd /home/copilot/email-assistant \
       && sudo -u copilot git fetch origin main \
       && sudo -u copilot git checkout ${SHA} \
       && sudo -u copilot .venv/bin/pip install -q -r requirements.txt \
       && systemctl restart copilot
     ```

     Pinned to `${{ github.sha }}` (not `git pull`) so re-running an older workflow run deploys *that* older commit — supports rollback.
  3. **Wait for SSM command** — polls `get-command-invocation` for up to 5 min; on `Failed/Cancelled/TimedOut` surfaces `StandardErrorContent`. **Smoke-check** then curls `/health` with 3 retries at 5s spacing.

### `docs/AWS_DEPLOY.md` — new "CI/CD" section

- **CD-1**: create the GitHub OIDC identity provider in IAM (one-time per AWS account).
- **CD-2/3/4**: trust policy (`:sub` claim restricted to `repo:H1shamM/ai-email-copilot:ref:refs/heads/main` — a fork can't steal credentials) and permission policy (scoped to one instance ARN + one document ARN + `GetCommandInvocation`).
- **CD-5**: `aws iam create-role` + `put-role-policy`.
- **CD-6**: `gh secret set AWS_DEPLOY_ROLE_ARN AWS_INSTANCE_ID`.
- **CD-7**: how to trigger + watch the workflow.
- **CD-8**: rollback procedure (Actions UI → previous successful run → *Re-run all jobs*).
- Teardown section updated with the role + OIDC provider cleanup.
- Troubleshooting table gains two rows: failed `AssumeRole` and failed smoke-check after a successful SSM command.

### `README.md`

Deployment section gains one paragraph describing the CD flow + link to the runbook.

## How to test

```bash
.venv/Scripts/black --check app/ tests/
.venv/Scripts/flake8 app/ tests/
.venv/Scripts/pytest tests/ --cov=app
```

Workflow YAML can be parsed by GitHub at PR time; once Track 1 is done, the **next push to `main` is the live test** (which is also exactly when issue #30 should close).

## Test coverage

```
TOTAL   755   58   92%   (unchanged from W6-A)
```

**92.32% overall** (gate 80%). 142 tests pass. Workflow YAML has no Python footprint.

## Checklist

- [x] PR title follows Conventional Commits (`feat:`)
- [x] Body links the issue (`Refs #30` — Track 1 follows; intentional non-`Closes`)
- [x] All public functions have type hints / docstrings (no Python changes here)
- [x] No comments restating *what* the code does
- [x] No secrets committed (the workflow consumes `${{ secrets.* }}`; nothing inline)
- [x] Coverage ≥ 80%
- [x] `black --check` and `flake8` pass locally
- [ ] CI green (will verify after push)
- [ ] `docs/PROGRESS.md` updated — deferred to the issue-closing comment, since #30 isn't done at this PR merge

## Why not `Closes #30`

Same reason as W6-A's PR #29: the workflow + runbook are necessary but not sufficient. The issue closes when the first push-to-main triggers a green deploy run, not at this PR merge. `Refs #30` keeps the issue open; once the first auto-deploy lands I'll close it manually with the run URL.

## Notes for the reviewer

- **OIDC over long-lived keys** — chosen even though access keys are quicker because the W6 phase is "simulating big tech" and OIDC is the canonical answer. Trust policy restricts to `:sub == repo:OWNER/REPO:ref:refs/heads/main` so a fork or non-`main` push can never assume.
- **`pip install` every deploy** — ~2s when `requirements.txt` is unchanged (pip's resolver is fast on a cache hit). If we later add wheels with native compile steps, switch to a `requirements.txt` hash check before reinstalling.
- **No staging environment** — single instance design. Rollback story is "re-run prior workflow"; deliberate trade-off documented in the issue.
- **Sudo policy** — SSM runs as root; we `sudo -u copilot` for git/pip and root-direct for `systemctl restart`. Avoids granting copilot user systemd privileges.
- **Concurrency `cancel-in-progress: false`** — a deliberate choice. Cancelling a mid-deploy run could leave the instance with a half-checked-out tree. Letting it complete and queueing the next is safer.