### PR TITLE
feat: register bot commands so / shows the autocomplete popup

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from app.gmail.service import get_recent_emails  # noqa: E402
 from app.ai.analyzer import analyze_email  # noqa: E402
 from app.database import db  # noqa: E402
 from app.telegram import bot as telegram_bot  # noqa: E402
+from app.telegram import handlers as telegram_handlers  # noqa: E402
 from app.telegram import push as telegram_push  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -31,6 +32,7 @@ async def startup():
     await telegram_bot.initialize()
     application = telegram_bot.get_application()
     await application.bot.set_webhook(url=webhook_url, secret_token=secret_token)
+    await telegram_handlers.set_bot_commands(application)
     logger.info("Telegram webhook registered at %s", webhook_url)
 
     if telegram_push.is_enabled_at_boot():

--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -4,7 +4,7 @@ import logging
 import os
 from functools import wraps
 
-from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram import BotCommand, InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.constants import ChatAction, ParseMode
 from telegram.ext import Application, CallbackQueryHandler, CommandHandler, ContextTypes
 
@@ -40,6 +40,28 @@ WELCOME = (
     "/resume - start push notifications\n"
     "/help - show this message"
 )
+
+# Telegram convention: lowercase descriptions, ≤ 60 chars to stay readable in
+# the popup. set_my_commands overwrites — re-running on every startup is safe
+# and keeps the list in sync with whatever this module declares.
+COMMANDS: list[BotCommand] = [
+    BotCommand("start", "show welcome message"),
+    BotCommand("help", "show available commands"),
+    BotCommand("unread", "list unread emails from gmail"),
+    BotCommand("analyze", "analyze emails with claude"),
+    BotCommand("inbox", "show recently analyzed emails"),
+    BotCommand("reply", "draft replies — usage: /reply <id>"),
+    BotCommand("pause", "pause push notifications"),
+    BotCommand("resume", "resume push notifications"),
+]
+
+
+async def set_bot_commands(application: Application) -> None:
+    """Register the command list so Telegram shows a popup when the user types /."""
+    try:
+        await application.bot.set_my_commands(COMMANDS)
+    except Exception:  # noqa: BLE001 — non-fatal cosmetic registration; bot still works without it
+        logger.warning("set_my_commands failed; / popup may be empty until next restart")
 
 
 def _is_authorized(chat_id: int | None) -> bool:

--- a/tests/unit/test_telegram_handlers.py
+++ b/tests/unit/test_telegram_handlers.py
@@ -710,6 +710,34 @@ async def test_cb_notify_done_ignores_malformed_callback(monkeypatch, reply_cont
 
 
 @pytest.mark.asyncio
+async def test_set_bot_commands_registers_all_commands():
+    """All 8 user-facing commands must be sent to Telegram's set_my_commands."""
+    application = MagicMock()
+    application.bot.set_my_commands = AsyncMock()
+
+    await handlers.set_bot_commands(application)
+
+    application.bot.set_my_commands.assert_awaited_once()
+    sent = application.bot.set_my_commands.await_args.args[0]
+    names = {c.command for c in sent}
+    assert names == {"start", "help", "unread", "analyze", "inbox", "reply", "pause", "resume"}
+    # Every command needs a non-empty description so the popup row isn't blank.
+    assert all(c.description for c in sent)
+
+
+@pytest.mark.asyncio
+async def test_set_bot_commands_swallows_failure(caplog):
+    """If Telegram is unreachable, startup must continue without crashing."""
+    application = MagicMock()
+    application.bot.set_my_commands = AsyncMock(side_effect=RuntimeError("network"))
+
+    with caplog.at_level("WARNING", logger="app.telegram.handlers"):
+        await handlers.set_bot_commands(application)  # must NOT raise
+
+    assert any("set_my_commands failed" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.asyncio
 async def test_unread_drops_unauthorized(monkeypatch):
     """The @authorized_only guard still applies to the new handlers."""
     monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")


### PR DESCRIPTION
Closes #32

## Summary

Typing `/` in the bot chat used to show nothing — Telegram's Bot API has `setMyCommands` for exactly this and we never called it. This PR adds the registration during FastAPI startup so all 8 commands appear in the popup as soon as the user types `/`.

## Changes

- `app/telegram/handlers.py` — `COMMANDS` list (8 `BotCommand` entries) + `set_bot_commands(application)` helper. Failures are logged-and-swallowed since the popup is cosmetic.
- `app/main.py` — startup hook awaits `set_bot_commands` right after `set_webhook`, so every restart re-syncs the list.
- `tests/unit/test_telegram_handlers.py` — two new tests: (1) all 8 commands are sent with non-empty descriptions; (2) a Telegram API failure during startup logs a warning instead of crashing.

## How to test

`ash
.venv/Scripts/black --check app/ tests/
.venv/Scripts/flake8 app/ tests/
.venv/Scripts/pytest tests/ --cov=app
`

Manual (post-merge, post-auto-deploy): open the bot in Telegram, type `/`. All 8 commands appear with descriptions.

## Test coverage

92.38% overall (gate 80%); 144 tests pass (2 new).

## Notes for the reviewer

- This will be the **first auto-deploy on a real merge to main** — previous green run was via `workflow_dispatch`. Good shakedown for the W6-B pipeline.
- Descriptions are lowercase per Telegram convention.