### PR TITLE
feat: add Calendar OAuth scope + service wrappers + DB helpers (W4-A)

### DIFF
--- a/app/calendar/__init__.py
+++ b/app/calendar/__init__.py
@@ -1,0 +1,1 @@
+"""Google Calendar integration package."""

--- a/app/calendar/service.py
+++ b/app/calendar/service.py
@@ -1,0 +1,80 @@
+"""Thin wrappers around Google Calendar API (events + freebusy).
+
+Mirrors app/gmail/service.py: a lazy singleton service builder plus
+small wrappers that the rest of the app composes against.
+"""
+
+from googleapiclient.discovery import build
+
+from app.gmail.auth import get_credentials
+
+_service = None
+
+
+def get_calendar_service():  # pragma: no cover
+    """Lazy singleton: build the Calendar discovery client once and cache it."""
+    global _service
+    if _service is None:
+        credentials = get_credentials()
+        _service = build("calendar", "v3", credentials=credentials)
+    return _service
+
+
+def reset_service_cache() -> None:
+    """Drop the cached service handle (used by tests to inject a fake)."""
+    global _service
+    _service = None
+
+
+def insert_event(event: dict, calendar_id: str = "primary") -> dict:
+    """Create an event on the given calendar; returns the inserted event resource."""
+    service = get_calendar_service()
+    return service.events().insert(calendarId=calendar_id, body=event).execute()
+
+
+def list_events(
+    time_min: str,
+    time_max: str,
+    calendar_id: str = "primary",
+    max_results: int = 50,
+) -> list[dict]:
+    """List events between two RFC3339 timestamps, ordered by start time."""
+    service = get_calendar_service()
+    response = (
+        service.events()
+        .list(
+            calendarId=calendar_id,
+            timeMin=time_min,
+            timeMax=time_max,
+            maxResults=max_results,
+            singleEvents=True,
+            orderBy="startTime",
+        )
+        .execute()
+    )
+    return response.get("items", [])
+
+
+def check_busy(
+    time_min: str,
+    time_max: str,
+    calendar_id: str = "primary",
+) -> list[dict]:
+    """Return busy intervals for the calendar in [time_min, time_max].
+
+    Each item is `{"start": rfc3339, "end": rfc3339}` from the Calendar API's
+    freebusy.query response — empty list means the window is free.
+    """
+    service = get_calendar_service()
+    response = (
+        service.freebusy()
+        .query(
+            body={
+                "timeMin": time_min,
+                "timeMax": time_max,
+                "items": [{"id": calendar_id}],
+            }
+        )
+        .execute()
+    )
+    return response.get("calendars", {}).get(calendar_id, {}).get("busy", [])

--- a/app/database/db.py
+++ b/app/database/db.py
@@ -68,6 +68,7 @@ def init_db():
             duration_minutes INTEGER,
             participants TEXT,
             location TEXT,
+            status TEXT NOT NULL DEFAULT 'detected',
             created_at TEXT DEFAULT (datetime('now')),
             FOREIGN KEY (email_id) REFERENCES emails(id)
         );
@@ -106,6 +107,14 @@ def init_db():
     email_cols = {r["name"] for r in conn.execute("PRAGMA table_info(emails)").fetchall()}
     if "notified_at" not in email_cols:
         conn.execute("ALTER TABLE emails ADD COLUMN notified_at TEXT")
+        conn.commit()
+
+    # Backfill calendar_events.status for DBs created before Week 4 Story A.
+    cal_cols = {r["name"] for r in conn.execute("PRAGMA table_info(calendar_events)").fetchall()}
+    if "status" not in cal_cols:
+        conn.execute(
+            "ALTER TABLE calendar_events ADD COLUMN status TEXT NOT NULL DEFAULT 'detected'"
+        )
         conn.commit()
 
     # Indexes — safe now that every referenced column exists.
@@ -329,6 +338,92 @@ def update_draft_status(
             conn.execute(
                 "UPDATE draft_replies SET status = ? WHERE id = ?",
                 (status, draft_id),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+CALENDAR_EVENT_STATUSES = {"detected", "created", "failed", "skipped"}
+
+
+def insert_calendar_event(
+    email_id: int,
+    title: str,
+    *,
+    event_date: str | None = None,
+    event_time: str | None = None,
+    duration_minutes: int | None = None,
+    participants: str | None = None,
+    location: str | None = None,
+    google_event_id: str | None = None,
+    status: str = "detected",
+) -> int:
+    """Persist a detected/created calendar event linked to an email; returns row id."""
+    if status not in CALENDAR_EVENT_STATUSES:
+        raise ValueError(
+            f"Invalid calendar event status {status!r}; allowed: {sorted(CALENDAR_EVENT_STATUSES)}"
+        )
+    conn = get_connection()
+    try:
+        cursor = conn.execute(
+            """INSERT INTO calendar_events
+               (email_id, title, event_date, event_time, duration_minutes,
+                participants, location, google_event_id, status)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                email_id,
+                title,
+                event_date,
+                event_time,
+                duration_minutes,
+                participants,
+                location,
+                google_event_id,
+                status,
+            ),
+        )
+        conn.commit()
+        return cursor.lastrowid
+    finally:
+        conn.close()
+
+
+def get_calendar_event_by_email(email_id: int) -> list[dict]:
+    """Return every calendar event linked to an email, newest first."""
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT * FROM calendar_events WHERE email_id = ? ORDER BY id DESC",
+            (email_id,),
+        ).fetchall()
+        return [dict(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def update_calendar_event_status(
+    event_row_id: int,
+    status: str,
+    *,
+    google_event_id: str | None = None,
+) -> None:
+    """Transition a calendar event row to a new status; optionally stamp google_event_id."""
+    if status not in CALENDAR_EVENT_STATUSES:
+        raise ValueError(
+            f"Invalid calendar event status {status!r}; allowed: {sorted(CALENDAR_EVENT_STATUSES)}"
+        )
+    conn = get_connection()
+    try:
+        if google_event_id is not None:
+            conn.execute(
+                "UPDATE calendar_events SET status = ?, google_event_id = ? WHERE id = ?",
+                (status, google_event_id, event_row_id),
+            )
+        else:
+            conn.execute(
+                "UPDATE calendar_events SET status = ? WHERE id = ?",
+                (status, event_row_id),
             )
         conn.commit()
     finally:

--- a/app/gmail/auth.py
+++ b/app/gmail/auth.py
@@ -7,6 +7,7 @@ SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",
     "https://www.googleapis.com/auth/gmail.modify",
     "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/calendar",
 ]
 
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -115,19 +115,25 @@ By end of week, must demonstrate:
 
 ---
 
-## 📋 Week 4: External Data + Knowledge (Apr 12-18) - UPCOMING
+## 🔄 Week 4: Calendar Integration (started 2026-05-10) - IN PROGRESS
 
-**Goals:**
-- Calendar integration
-- Meeting detection
-- Event creation
+**Pivot back from Week 6:** with AWS deploy + auto-deploy live, returning to feature work. Week 4 PRD-aligned scope (Feature 5 — Google Calendar) ahead of Week 5 (Agentic).
 
-**High-Level Tasks:**
-1. Google Calendar API integration
-2. Meeting detection with Claude
-3. Natural language date parsing
-4. Calendar event creation
-5. UI for calendar features
+### Stories
+- 🔄 **Story W4-A** ([#34](https://github.com/H1shamM/ai-email-copilot/issues/34)) — Calendar OAuth scope + `app/calendar/service.py` wrappers + `calendar_events.status` migration + DB helpers
+- 🔲 **Story W4-B** — Meeting detection from email body (Claude-driven NL date resolution)
+- 🔲 **Story W4-C** — Telegram `/schedule` flow with approve-before-create + free/busy conflict check
+
+### Re-auth required after Story W4-A merges
+
+Adding `https://www.googleapis.com/auth/calendar` to `SCOPES` invalidates any existing `token.pickle`. After pulling the merged change:
+
+```powershell
+Remove-Item token.pickle -ErrorAction SilentlyContinue
+.venv/Scripts/python -c "from app.gmail.auth import get_credentials; get_credentials()"
+```
+
+The browser flow now lists Calendar alongside the Gmail scopes — grant it. Subsequent runs reuse the refreshed token transparently.
 
 ---
 

--- a/tests/integration/test_calendar_integration.py
+++ b/tests/integration/test_calendar_integration.py
@@ -1,0 +1,42 @@
+"""Integration tests against the real Google Calendar API.
+
+Run with: pytest -m integration tests/integration/test_calendar_integration.py
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.path.exists("token.pickle"),
+        reason="Requires authenticated token.pickle (re-auth after Calendar scope added)",
+    ),
+]
+
+
+def _rfc3339(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_list_events_next_24h_returns_list():
+    """Live Calendar call returns a list (possibly empty) for the next 24h window."""
+    from app.calendar.service import list_events
+
+    now = datetime.now(timezone.utc)
+    events = list_events(_rfc3339(now), _rfc3339(now + timedelta(days=1)))
+    assert isinstance(events, list)
+
+
+def test_check_busy_next_24h_returns_list():
+    """freebusy.query returns a list of busy intervals (possibly empty) for the next 24h."""
+    from app.calendar.service import check_busy
+
+    now = datetime.now(timezone.utc)
+    busy = check_busy(_rfc3339(now), _rfc3339(now + timedelta(days=1)))
+    assert isinstance(busy, list)
+    for interval in busy:
+        assert "start" in interval
+        assert "end" in interval

--- a/tests/unit/test_calendar_service.py
+++ b/tests/unit/test_calendar_service.py
@@ -1,0 +1,105 @@
+"""Unit tests for app.calendar.service wrappers (no live Calendar calls)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.calendar import service as cal_service
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Ensure each test starts with no cached service handle."""
+    cal_service.reset_service_cache()
+    yield
+    cal_service.reset_service_cache()
+
+
+def _install_fake_service(monkeypatch) -> MagicMock:
+    """Replace the cached Calendar service with a MagicMock so wrappers exercise it."""
+    fake = MagicMock(name="calendar_service")
+    monkeypatch.setattr(cal_service, "_service", fake)
+    return fake
+
+
+def test_insert_event_calls_events_insert(monkeypatch):
+    fake = _install_fake_service(monkeypatch)
+    expected = {"id": "evt_123", "summary": "Test"}
+    fake.events.return_value.insert.return_value.execute.return_value = expected
+
+    payload = {"summary": "Test", "start": {"dateTime": "2026-05-11T10:00:00Z"}}
+    result = cal_service.insert_event(payload)
+
+    assert result == expected
+    fake.events.return_value.insert.assert_called_once_with(calendarId="primary", body=payload)
+
+
+def test_insert_event_honors_calendar_id(monkeypatch):
+    fake = _install_fake_service(monkeypatch)
+    fake.events.return_value.insert.return_value.execute.return_value = {"id": "evt"}
+
+    cal_service.insert_event({"summary": "x"}, calendar_id="work@group.calendar.google.com")
+
+    fake.events.return_value.insert.assert_called_once_with(
+        calendarId="work@group.calendar.google.com", body={"summary": "x"}
+    )
+
+
+def test_list_events_returns_items(monkeypatch):
+    fake = _install_fake_service(monkeypatch)
+    fake.events.return_value.list.return_value.execute.return_value = {
+        "items": [{"id": "a"}, {"id": "b"}]
+    }
+
+    items = cal_service.list_events("2026-05-10T00:00:00Z", "2026-05-11T00:00:00Z")
+
+    assert items == [{"id": "a"}, {"id": "b"}]
+    fake.events.return_value.list.assert_called_once_with(
+        calendarId="primary",
+        timeMin="2026-05-10T00:00:00Z",
+        timeMax="2026-05-11T00:00:00Z",
+        maxResults=50,
+        singleEvents=True,
+        orderBy="startTime",
+    )
+
+
+def test_list_events_returns_empty_when_no_items(monkeypatch):
+    fake = _install_fake_service(monkeypatch)
+    fake.events.return_value.list.return_value.execute.return_value = {}
+
+    assert cal_service.list_events("a", "b") == []
+
+
+def test_check_busy_returns_busy_intervals(monkeypatch):
+    fake = _install_fake_service(monkeypatch)
+    fake.freebusy.return_value.query.return_value.execute.return_value = {
+        "calendars": {
+            "primary": {"busy": [{"start": "2026-05-10T09:00:00Z", "end": "2026-05-10T10:00:00Z"}]}
+        }
+    }
+
+    busy = cal_service.check_busy("2026-05-10T00:00:00Z", "2026-05-10T23:59:59Z")
+
+    assert busy == [{"start": "2026-05-10T09:00:00Z", "end": "2026-05-10T10:00:00Z"}]
+    fake.freebusy.return_value.query.assert_called_once_with(
+        body={
+            "timeMin": "2026-05-10T00:00:00Z",
+            "timeMax": "2026-05-10T23:59:59Z",
+            "items": [{"id": "primary"}],
+        }
+    )
+
+
+def test_check_busy_returns_empty_when_calendar_missing(monkeypatch):
+    fake = _install_fake_service(monkeypatch)
+    fake.freebusy.return_value.query.return_value.execute.return_value = {"calendars": {}}
+
+    assert cal_service.check_busy("a", "b") == []
+
+
+def test_reset_service_cache_clears_state(monkeypatch):
+    _install_fake_service(monkeypatch)
+    assert cal_service._service is not None
+    cal_service.reset_service_cache()
+    assert cal_service._service is None

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -277,3 +277,144 @@ def test_get_or_create_telegram_user_bumps_last_seen():
     assert second["last_seen_at"] >= first["last_seen_at"]
     # created_at must NOT change on a re-call
     assert first["created_at"] == second["created_at"]
+
+
+def test_insert_calendar_event_round_trips():
+    email_row = _make_email("cal_one")
+    event_row = db.insert_calendar_event(
+        email_row,
+        "Sync with Alice",
+        event_date="2026-05-12",
+        event_time="14:00",
+        duration_minutes=30,
+        participants="alice@example.com",
+        location="Zoom",
+    )
+    events = db.get_calendar_event_by_email(email_row)
+    assert len(events) == 1
+    e = events[0]
+    assert e["id"] == event_row
+    assert e["title"] == "Sync with Alice"
+    assert e["event_date"] == "2026-05-12"
+    assert e["duration_minutes"] == 30
+    assert e["participants"] == "alice@example.com"
+    assert e["location"] == "Zoom"
+    assert e["status"] == "detected"
+    assert e["google_event_id"] is None
+
+
+def test_get_calendar_event_by_email_returns_newest_first():
+    email_row = _make_email("cal_multi")
+    db.insert_calendar_event(email_row, "First detection")
+    db.insert_calendar_event(email_row, "Second detection")
+    events = db.get_calendar_event_by_email(email_row)
+    assert [e["title"] for e in events] == ["Second detection", "First detection"]
+
+
+def test_get_calendar_event_by_email_empty_when_none_exist():
+    email_row = _make_email("cal_none")
+    assert db.get_calendar_event_by_email(email_row) == []
+
+
+def test_update_calendar_event_status_stamps_google_event_id():
+    email_row = _make_email("cal_create")
+    event_row = db.insert_calendar_event(email_row, "Quick chat")
+    db.update_calendar_event_status(event_row, "created", google_event_id="goog_evt_42")
+    after = db.get_calendar_event_by_email(email_row)[0]
+    assert after["status"] == "created"
+    assert after["google_event_id"] == "goog_evt_42"
+
+
+def test_update_calendar_event_status_without_google_id_leaves_it():
+    email_row = _make_email("cal_skip")
+    event_row = db.insert_calendar_event(email_row, "Maybe meeting", google_event_id="prev")
+    db.update_calendar_event_status(event_row, "skipped")
+    after = db.get_calendar_event_by_email(email_row)[0]
+    assert after["status"] == "skipped"
+    assert after["google_event_id"] == "prev"
+
+
+def test_insert_calendar_event_rejects_unknown_status():
+    email_row = _make_email("cal_bad")
+    with pytest.raises(ValueError, match="Invalid calendar event status"):
+        db.insert_calendar_event(email_row, "x", status="confused")
+
+
+def test_update_calendar_event_status_rejects_unknown_status():
+    email_row = _make_email("cal_bad2")
+    event_row = db.insert_calendar_event(email_row, "x")
+    with pytest.raises(ValueError, match="Invalid calendar event status"):
+        db.update_calendar_event_status(event_row, "definitely-not-real")
+
+
+def test_init_db_backfills_calendar_events_status(monkeypatch):
+    """A DB created before Week 4 (calendar_events with no status column) must
+    migrate cleanly when init_db runs again."""
+    fd, legacy_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    try:
+        legacy = sqlite3.connect(legacy_path)
+        legacy.executescript("""
+            CREATE TABLE emails (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                gmail_message_id TEXT UNIQUE NOT NULL,
+                thread_id TEXT,
+                sender TEXT NOT NULL,
+                subject TEXT,
+                body TEXT,
+                snippet TEXT,
+                received_date TEXT,
+                ai_summary TEXT,
+                category TEXT,
+                sentiment TEXT,
+                action_required TEXT,
+                urgency_score INTEGER,
+                is_read INTEGER DEFAULT 0,
+                is_archived INTEGER DEFAULT 0,
+                is_starred INTEGER DEFAULT 0,
+                processed_at TEXT,
+                notified_at TEXT,
+                created_at TEXT
+            );
+            CREATE TABLE draft_replies (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                email_id INTEGER NOT NULL,
+                tone TEXT NOT NULL,
+                draft_text TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'pending',
+                was_sent INTEGER DEFAULT 0,
+                sent_at TEXT,
+                created_at TEXT
+            );
+            CREATE TABLE calendar_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                email_id INTEGER NOT NULL,
+                google_event_id TEXT,
+                title TEXT NOT NULL,
+                event_date TEXT,
+                event_time TEXT,
+                duration_minutes INTEGER,
+                participants TEXT,
+                location TEXT,
+                created_at TEXT,
+                FOREIGN KEY (email_id) REFERENCES emails(id)
+            );
+            """)
+        legacy.commit()
+        legacy.close()
+
+        monkeypatch.setenv("DATABASE_PATH", legacy_path)
+        reloaded = importlib.reload(db)
+        reloaded.init_db()
+
+        check = reloaded.get_connection()
+        try:
+            cols = {r["name"] for r in check.execute("PRAGMA table_info(calendar_events)")}
+        finally:
+            check.close()
+        assert "status" in cols
+    finally:
+        try:
+            os.unlink(legacy_path)
+        except PermissionError:
+            pass


### PR DESCRIPTION
## Summary

Foundation story for Week 4 Calendar Integration (Feature 5). Adds the Calendar OAuth scope, a thin service-wrapper module mirroring `app/gmail/service.py`, a `status` column + backfill migration on the existing `calendar_events` table, and three DB helpers that downstream stories (W4-B meeting detection, W4-C `/schedule` flow) will compose against.

Closes #34

## Changes

**Auth & service**
- Append `https://www.googleapis.com/auth/calendar` to `SCOPES` in `app/gmail/auth.py`
- New `app/calendar/service.py` — lazy `get_calendar_service()` singleton + `insert_event`, `list_events`, `check_busy` (freebusy) wrappers + `reset_service_cache()` for tests

**Database**
- `calendar_events.status` column added to fresh-DB schema and via the same backfill pattern as `draft_replies.status` / `emails.notified_at`
- `CALENDAR_EVENT_STATUSES = {"detected", "created", "failed", "skipped"}` enum
- Helpers: `insert_calendar_event`, `get_calendar_event_by_email`, `update_calendar_event_status` — all follow the `try/finally: conn.close()` pattern

**Tests**
- `tests/unit/test_calendar_service.py` — 7 tests, mock the discovery client via the cached `_service` handle (no real Calendar calls)
- `tests/unit/test_db.py` — 7 new helper tests + a legacy-schema migration test for `calendar_events.status`
- `tests/integration/test_calendar_integration.py` — 2 live-API tests, self-skip without `token.pickle`

**Docs**
- `docs/PROGRESS.md` Week 4 section flipped to in-progress with story breakdown and re-auth steps

## How to test

```powershell
.venv/Scripts/black --check app/ tests/
.venv/Scripts/flake8 app/ tests/ --max-line-length=100
.venv/Scripts/pytest tests/ --cov=app
```

Local result: **159 passed, 92.81% coverage**, `app/calendar/service.py` at 100%.

### Required re-auth after merge

The new Calendar scope invalidates the existing `token.pickle`:

```powershell
Remove-Item token.pickle -ErrorAction SilentlyContinue
.venv/Scripts/python -c "from app.gmail.auth import get_credentials; get_credentials()"
```

The browser flow now lists Calendar alongside the Gmail scopes — grant it. Then optionally run the live integration test:

```powershell
.venv/Scripts/pytest -m integration tests/integration/test_calendar_integration.py
```

- [x] Unit tests added under `tests/unit/`
- [x] Integration test added (new external API boundary)
- [ ] Manual verification steps:
  - Re-auth locally, confirm Calendar appears on consent screen
  - Run integration test against real Calendar, confirm it returns a list

## Checklist

- [x] PR title follows Conventional Commits (`feat:`)
- [x] Body links the issue with `Closes #34`
- [x] All public functions have type hints
- [x] All public functions have a one-line docstring
- [x] No comments restating *what* the code does
- [x] No secrets, tokens, or real credentials committed
- [x] Coverage ≥ 80% on the changed module(s) (calendar/service.py 100%, database/db.py 96%)
- [x] `black --check` and `flake8` pass locally
- [ ] CI is green (will verify after push)
- [x] `docs/PROGRESS.md` updated

## Notes for the reviewer

- The `calendar_events` table already existed in `init_db()` from an earlier scaffolding pass — I kept the existing schema (event_date/event_time/duration/participants/location matches the PRD Feature 5 spec) and only added the `status` column for tracking detected vs. created events.
- Out of scope (deferred to W4-B/C): meeting detection from email body, NL date parsing, `/schedule` Telegram command, conflict-detection UX.
- Re-auth requirement is the one human-in-the-loop step. After merge I'll re-auth my own `token.pickle` before pulling the next story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
