### PR TITLE
feat: detect meetings from email body and persist (W4-B)

### DIFF
--- a/app/ai/meeting_detector.py
+++ b/app/ai/meeting_detector.py
@@ -1,0 +1,139 @@
+"""Detect meeting requests in emails and persist them as calendar_events rows.
+
+Mirrors app/ai/analyzer.py: lazy Anthropic client, prompt as module constant,
+JSON-only response, returns None on parse/API failure. Persistence wrapper is
+idempotent so the same email can be re-analyzed without duplicating rows.
+"""
+
+import json
+import os
+
+from anthropic import Anthropic
+
+from app.database import db
+
+_client = None
+
+CONFIDENCE_THRESHOLD = 0.6
+
+MEETING_MODEL = "claude-sonnet-4-20250514"
+
+MEETING_PROMPT = """Extract meeting/event details from this email and respond with JSON.
+
+EMAIL:
+From: {sender}
+Subject: {subject}
+Received: {received}
+Body: {body}
+
+Resolve any natural-language dates (e.g. "next Tuesday at 3pm") against the
+Received date above. Always return ISO-8601 UTC for proposed_datetime, or null
+if no date can be confidently extracted. If the email is NOT a meeting/event
+request (e.g. it's a newsletter, FYI, or pure information), set is_meeting=false.
+
+Respond ONLY with valid JSON (no markdown fences):
+{{
+  "is_meeting": true|false,
+  "title": "short event title or null",
+  "proposed_datetime": "YYYY-MM-DDTHH:MM:SSZ or null",
+  "duration_minutes": integer or null,
+  "participants": ["email1@x.com", ...],
+  "location": "Zoom URL, physical address, or null",
+  "confidence": 0.0-1.0,
+  "notes": "any ambiguity or caveat, or null"
+}}"""
+
+
+def _get_client():
+    global _client
+    if _client is None:
+        _client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+    return _client
+
+
+def detect_meeting(email_data: dict) -> dict | None:
+    """Ask Claude to extract structured meeting fields from an email."""
+    prompt = MEETING_PROMPT.format(
+        sender=email_data.get("sender", "Unknown"),
+        subject=email_data.get("subject", "No subject"),
+        received=email_data.get("received_date") or email_data.get("date") or "Unknown",
+        body=email_data.get("body") or email_data.get("snippet", ""),
+    )
+
+    try:
+        message = _get_client().messages.create(
+            model=MEETING_MODEL,
+            max_tokens=1000,
+            messages=[{"role": "user", "content": prompt}],
+        )
+
+        response_text = message.content[0].text.strip()
+
+        if response_text.startswith("```"):
+            response_text = response_text.split("```")[1]
+            if response_text.startswith("json"):
+                response_text = response_text[4:]
+            response_text = response_text.strip()
+
+        parsed = json.loads(response_text)
+    except json.JSONDecodeError as e:
+        print(f"Failed to parse meeting JSON: {e}")
+        return None
+    except Exception as e:
+        print(f"Claude API error in detect_meeting: {e}")
+        return None
+
+    participants = parsed.get("participants") or []
+    if not isinstance(participants, list):
+        participants = []
+    parsed["participants"] = participants
+    return parsed
+
+
+def _split_iso_datetime(iso: str | None) -> tuple[str | None, str | None]:
+    """Split an ISO-8601 datetime into (YYYY-MM-DD, HH:MM:SS) parts.
+
+    Returns (None, None) when the input is missing or unparseable so callers
+    can write null event_date/event_time rather than crash on a bad model response.
+    """
+    if not iso or not isinstance(iso, str):
+        return None, None
+    cleaned = iso.replace("Z", "").strip()
+    if "T" not in cleaned:
+        return cleaned or None, None
+    date_part, _, time_part = cleaned.partition("T")
+    return (date_part or None), (time_part or None)
+
+
+def maybe_detect_meeting(email_row: dict, analysis: dict) -> int | None:
+    """Run the detector when analysis says Schedule, persist a row, return its id.
+
+    Idempotent: skips work if `calendar_events` already has a row for this email.
+    Returns the new event row id, or None if nothing was persisted (not a meeting,
+    low confidence, detector failure, or already detected).
+    """
+    if analysis.get("action_required") != "Schedule":
+        return None
+    if db.get_calendar_event_by_email(email_row["id"]):
+        return None
+
+    meeting = detect_meeting(email_row)
+    if not meeting or not meeting.get("is_meeting"):
+        return None
+    confidence = meeting.get("confidence") or 0.0
+    if confidence < CONFIDENCE_THRESHOLD:
+        return None
+
+    event_date, event_time = _split_iso_datetime(meeting.get("proposed_datetime"))
+    participants = ", ".join(meeting.get("participants") or []) or None
+
+    return db.insert_calendar_event(
+        email_id=email_row["id"],
+        title=meeting.get("title") or (email_row.get("subject") or "Untitled meeting"),
+        event_date=event_date,
+        event_time=event_time,
+        duration_minutes=meeting.get("duration_minutes"),
+        participants=participants,
+        location=meeting.get("location"),
+        status="detected",
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI, Header, HTTPException, Query, Request  # noqa: E402
 
 from app.gmail.service import get_recent_emails  # noqa: E402
 from app.ai.analyzer import analyze_email  # noqa: E402
+from app.ai.meeting_detector import maybe_detect_meeting  # noqa: E402
 from app.database import db  # noqa: E402
 from app.telegram import bot as telegram_bot  # noqa: E402
 from app.telegram import handlers as telegram_handlers  # noqa: E402
@@ -121,6 +122,7 @@ def analyze_stored_emails():
         analysis = analyze_email(email)
         if analysis:
             db.update_analysis(email["gmail_message_id"], analysis)
+            maybe_detect_meeting(email, analysis)
             results.append(
                 {
                     "gmail_message_id": email["gmail_message_id"],

--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -9,6 +9,7 @@ from telegram.constants import ChatAction, ParseMode
 from telegram.ext import Application, CallbackQueryHandler, CommandHandler, ContextTypes
 
 from app.ai.analyzer import analyze_email
+from app.ai.meeting_detector import maybe_detect_meeting
 from app.ai.reply_generator import generate_replies, regenerate_one
 from app.database import db
 from app.gmail.service import get_recent_emails as gmail_fetch_recent
@@ -166,6 +167,7 @@ async def analyze(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             )
             continue
         db.update_analysis(email["gmail_message_id"], analysis)
+        maybe_detect_meeting(email, analysis)
         blocks.append(format_analysis_entry(email, analysis))
 
     if blocks:

--- a/app/telegram/push.py
+++ b/app/telegram/push.py
@@ -21,6 +21,7 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.constants import ParseMode
 
 from app.ai.analyzer import analyze_email
+from app.ai.meeting_detector import maybe_detect_meeting
 from app.database import db
 from app.gmail.service import get_recent_emails as gmail_fetch_recent
 from app.telegram.formatting import chunk_messages, format_notification
@@ -146,6 +147,7 @@ async def _ingest_and_analyze() -> None:
             continue
         if analysis:
             await asyncio.to_thread(db.update_analysis, em["gmail_message_id"], analysis)
+            await asyncio.to_thread(maybe_detect_meeting, em, analysis)
 
 
 def _authorized_chat_id() -> int | None:

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -120,8 +120,8 @@ By end of week, must demonstrate:
 **Pivot back from Week 6:** with AWS deploy + auto-deploy live, returning to feature work. Week 4 PRD-aligned scope (Feature 5 — Google Calendar) ahead of Week 5 (Agentic).
 
 ### Stories
-- 🔄 **Story W4-A** ([#34](https://github.com/H1shamM/ai-email-copilot/issues/34)) — Calendar OAuth scope + `app/calendar/service.py` wrappers + `calendar_events.status` migration + DB helpers
-- 🔲 **Story W4-B** — Meeting detection from email body (Claude-driven NL date resolution)
+- ✅ **Story W4-A** ([#34](https://github.com/H1shamM/ai-email-copilot/issues/34) / PR [#35](https://github.com/H1shamM/ai-email-copilot/pull/35)) — Calendar OAuth scope + `app/calendar/service.py` wrappers + `calendar_events.status` migration + DB helpers
+- 🔄 **Story W4-B** ([#36](https://github.com/H1shamM/ai-email-copilot/issues/36)) — Meeting detection from email body (Claude-driven NL date resolution) + idempotent persistence into `calendar_events`
 - 🔲 **Story W4-C** — Telegram `/schedule` flow with approve-before-create + free/busy conflict check
 
 ### Re-auth required after Story W4-A merges

--- a/tests/integration/test_meeting_detector_integration.py
+++ b/tests/integration/test_meeting_detector_integration.py
@@ -1,0 +1,45 @@
+"""Integration tests for Claude meeting detection.
+
+Run with: pytest -m integration tests/integration/test_meeting_detector_integration.py
+
+Costs money — every run hits the real Anthropic API. Keep test count low.
+"""
+
+import os
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.getenv("ANTHROPIC_API_KEY"),
+        reason="Requires ANTHROPIC_API_KEY env var",
+    ),
+]
+
+
+def test_detect_returns_structured_meeting_for_clear_request():
+    """A meeting request email yields is_meeting=True with the documented shape."""
+    from app.ai.meeting_detector import detect_meeting
+
+    result = detect_meeting(
+        {
+            "sender": "alice@example.com",
+            "subject": "Sync next Tuesday",
+            "received_date": "Mon, 10 May 2026 09:00:00 +0000",
+            "body": (
+                "Hi! Can we meet next Tuesday at 3pm UK time for 30 minutes? "
+                "We'll use Zoom. — Alice"
+            ),
+        }
+    )
+
+    assert result is not None, "Claude returned None — check API key / quota"
+    assert result.get("is_meeting") is True
+    assert isinstance(result.get("confidence"), (int, float))
+    assert 0.0 <= result["confidence"] <= 1.0
+    assert isinstance(result.get("participants"), list)
+    # `proposed_datetime` may be None on ambiguous parsing, but for this input
+    # we expect Claude to anchor on the received date and emit ISO 8601.
+    if result.get("proposed_datetime"):
+        assert "T" in result["proposed_datetime"]

--- a/tests/unit/test_meeting_detector.py
+++ b/tests/unit/test_meeting_detector.py
@@ -1,0 +1,264 @@
+"""Tests for app.ai.meeting_detector with mocked Claude client."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from app.ai import meeting_detector
+from app.database import db
+
+
+def _make_response(text: str):
+    msg = MagicMock()
+    msg.content = [MagicMock(text=text)]
+    return msg
+
+
+def _meeting_payload(**overrides) -> str:
+    base = {
+        "is_meeting": True,
+        "title": "Sync with Alice",
+        "proposed_datetime": "2026-05-19T15:00:00Z",
+        "duration_minutes": 30,
+        "participants": ["alice@example.com"],
+        "location": "Zoom",
+        "confidence": 0.92,
+        "notes": None,
+    }
+    base.update(overrides)
+    return json.dumps(base)
+
+
+@patch.object(meeting_detector, "_get_client")
+def test_detect_meeting_parses_valid_json(mock_get_client):
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = _make_response(_meeting_payload())
+    mock_get_client.return_value = mock_client
+
+    result = meeting_detector.detect_meeting(
+        {"sender": "alice@example.com", "subject": "Sync", "body": "let's meet"}
+    )
+
+    assert result["is_meeting"] is True
+    assert result["proposed_datetime"] == "2026-05-19T15:00:00Z"
+    assert result["confidence"] == 0.92
+    assert result["participants"] == ["alice@example.com"]
+
+
+@patch.object(meeting_detector, "_get_client")
+def test_detect_meeting_strips_markdown_fences(mock_get_client):
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = _make_response(
+        "```json\n" + _meeting_payload(is_meeting=False, confidence=0.05) + "\n```"
+    )
+    mock_get_client.return_value = mock_client
+
+    result = meeting_detector.detect_meeting({"sender": "n@n", "subject": "FYI", "body": ""})
+    assert result["is_meeting"] is False
+
+
+@patch.object(meeting_detector, "_get_client")
+def test_detect_meeting_returns_none_on_invalid_json(mock_get_client):
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = _make_response("not json")
+    mock_get_client.return_value = mock_client
+
+    assert meeting_detector.detect_meeting({"sender": "a", "subject": "s", "body": ""}) is None
+
+
+@patch.object(meeting_detector, "_get_client")
+def test_detect_meeting_returns_none_on_api_error(mock_get_client):
+    mock_client = MagicMock()
+    mock_client.messages.create.side_effect = RuntimeError("API down")
+    mock_get_client.return_value = mock_client
+
+    assert meeting_detector.detect_meeting({"sender": "a", "subject": "s", "body": ""}) is None
+
+
+@patch.object(meeting_detector, "_get_client")
+def test_detect_meeting_normalizes_participants_to_list(mock_get_client):
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = _make_response(_meeting_payload(participants=None))
+    mock_get_client.return_value = mock_client
+
+    result = meeting_detector.detect_meeting({"sender": "a", "subject": "s", "body": ""})
+    assert result["participants"] == []
+
+
+@patch.object(meeting_detector, "_get_client")
+def test_detect_meeting_anchors_prompt_on_received_date(mock_get_client):
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured["prompt"] = kwargs["messages"][0]["content"]
+        return _make_response(_meeting_payload())
+
+    mock_client = MagicMock()
+    mock_client.messages.create.side_effect = fake_create
+    mock_get_client.return_value = mock_client
+
+    meeting_detector.detect_meeting(
+        {
+            "sender": "a@a",
+            "subject": "s",
+            "body": "next Tuesday at 3pm",
+            "received_date": "Mon, 10 May 2026 09:00:00 +0000",
+        }
+    )
+    assert "Mon, 10 May 2026 09:00:00 +0000" in captured["prompt"]
+
+
+def test_split_iso_datetime_handles_full_value():
+    assert meeting_detector._split_iso_datetime("2026-05-19T15:00:00Z") == (
+        "2026-05-19",
+        "15:00:00",
+    )
+
+
+def test_split_iso_datetime_handles_date_only():
+    assert meeting_detector._split_iso_datetime("2026-05-19") == ("2026-05-19", None)
+
+
+def test_split_iso_datetime_handles_none_and_garbage():
+    assert meeting_detector._split_iso_datetime(None) == (None, None)
+    assert meeting_detector._split_iso_datetime("") == (None, None)
+    assert meeting_detector._split_iso_datetime(123) == (None, None)
+
+
+def _insert_email(gmail_id: str = "mt_one") -> int:
+    return db.insert_email(
+        {
+            "id": gmail_id,
+            "thread_id": "t",
+            "sender": "alice@example.com",
+            "subject": "Sync request",
+            "body": "let's meet next Tuesday",
+            "snippet": "",
+            "date": "Mon, 10 May 2026 09:00:00 +0000",
+        }
+    )
+
+
+def _email_row(email_row_id: int) -> dict:
+    row = db.get_email_by_row_id(email_row_id)
+    assert row is not None
+    return row
+
+
+@patch.object(meeting_detector, "_get_client")
+def test_maybe_detect_meeting_persists_when_schedule_and_confident(mock_get_client):
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = _make_response(_meeting_payload())
+    mock_get_client.return_value = mock_client
+
+    email_row_id = _insert_email("mt_persist")
+    email = _email_row(email_row_id)
+
+    new_id = meeting_detector.maybe_detect_meeting(email, {"action_required": "Schedule"})
+
+    assert new_id is not None
+    events = db.get_calendar_event_by_email(email_row_id)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["title"] == "Sync with Alice"
+    assert ev["event_date"] == "2026-05-19"
+    assert ev["event_time"] == "15:00:00"
+    assert ev["duration_minutes"] == 30
+    assert ev["participants"] == "alice@example.com"
+    assert ev["location"] == "Zoom"
+    assert ev["status"] == "detected"
+
+
+@patch.object(meeting_detector, "_get_client")
+def test_maybe_detect_meeting_skips_when_action_not_schedule(mock_get_client):
+    email_row_id = _insert_email("mt_skip_action")
+    email = _email_row(email_row_id)
+
+    new_id = meeting_detector.maybe_detect_meeting(email, {"action_required": "Reply"})
+
+    assert new_id is None
+    assert db.get_calendar_event_by_email(email_row_id) == []
+    mock_get_client.assert_not_called()
+
+
+@patch.object(meeting_detector, "_get_client")
+def test_maybe_detect_meeting_skips_low_confidence(mock_get_client):
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = _make_response(
+        _meeting_payload(confidence=0.3, proposed_datetime=None, notes="ambiguous")
+    )
+    mock_get_client.return_value = mock_client
+
+    email_row_id = _insert_email("mt_low_conf")
+    email = _email_row(email_row_id)
+
+    new_id = meeting_detector.maybe_detect_meeting(email, {"action_required": "Schedule"})
+
+    assert new_id is None
+    assert db.get_calendar_event_by_email(email_row_id) == []
+
+
+@patch.object(meeting_detector, "_get_client")
+def test_maybe_detect_meeting_skips_when_not_meeting(mock_get_client):
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = _make_response(
+        _meeting_payload(is_meeting=False, confidence=0.95)
+    )
+    mock_get_client.return_value = mock_client
+
+    email_row_id = _insert_email("mt_not_meeting")
+    email = _email_row(email_row_id)
+
+    new_id = meeting_detector.maybe_detect_meeting(email, {"action_required": "Schedule"})
+
+    assert new_id is None
+    assert db.get_calendar_event_by_email(email_row_id) == []
+
+
+@patch.object(meeting_detector, "_get_client")
+def test_maybe_detect_meeting_is_idempotent(mock_get_client):
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = _make_response(_meeting_payload())
+    mock_get_client.return_value = mock_client
+
+    email_row_id = _insert_email("mt_idempotent")
+    email = _email_row(email_row_id)
+
+    first_id = meeting_detector.maybe_detect_meeting(email, {"action_required": "Schedule"})
+    second_id = meeting_detector.maybe_detect_meeting(email, {"action_required": "Schedule"})
+
+    assert first_id is not None
+    assert second_id is None
+    # Detector should not have been invoked the second time (existing row short-circuits).
+    assert mock_client.messages.create.call_count == 1
+    assert len(db.get_calendar_event_by_email(email_row_id)) == 1
+
+
+@patch.object(meeting_detector, "_get_client")
+def test_maybe_detect_meeting_handles_detector_returning_none(mock_get_client):
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = _make_response("not json")
+    mock_get_client.return_value = mock_client
+
+    email_row_id = _insert_email("mt_none")
+    email = _email_row(email_row_id)
+
+    new_id = meeting_detector.maybe_detect_meeting(email, {"action_required": "Schedule"})
+
+    assert new_id is None
+    assert db.get_calendar_event_by_email(email_row_id) == []
+
+
+@patch.object(meeting_detector, "_get_client")
+def test_maybe_detect_meeting_falls_back_to_subject_when_title_missing(mock_get_client):
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = _make_response(_meeting_payload(title=None))
+    mock_get_client.return_value = mock_client
+
+    email_row_id = _insert_email("mt_no_title")
+    email = _email_row(email_row_id)
+
+    new_id = meeting_detector.maybe_detect_meeting(email, {"action_required": "Schedule"})
+
+    assert new_id is not None
+    ev = db.get_calendar_event_by_email(email_row_id)[0]
+    assert ev["title"] == "Sync request"


### PR DESCRIPTION
## Summary

Second story for Week 4. The analyzer already flags emails with `action_required="Schedule"`; this adds a Claude-driven meeting extractor that fills in title/datetime/duration/participants/location for those emails and persists them. W4-C will use those rows to offer a Telegram `/schedule` flow with approve-before-create + free/busy conflict check.

Closes #36

## Changes

**New module**
- `app/ai/meeting_detector.py` — mirrors `app/ai/analyzer.py` (lazy `_get_client()`, prompt as module constant, JSON-only response, returns `None` on parse/API failure)
- `detect_meeting(email)` returns `{is_meeting, title, proposed_datetime (ISO-8601 UTC or null), duration_minutes, participants (list), location, confidence, notes}` — Claude resolves NL dates against the email's Received header so we avoid importing `dateutil` and dealing with timezones
- `maybe_detect_meeting(email_row, analysis)` is the idempotent persistence wrapper — no-op unless `action_required == "Schedule"`, skips when `calendar_events` already has a row for this email, skips when `confidence < CONFIDENCE_THRESHOLD` (0.6), splits ISO datetime into the existing `event_date` / `event_time` columns
- `_split_iso_datetime` helper handles the model occasionally returning bare dates or `null`

**Wired into the 3 analyze call sites**
- `app/main.py` — `/emails/analyze` endpoint
- `app/telegram/handlers.py` — `/analyze` Telegram command
- `app/telegram/push.py` — push scheduler (via `asyncio.to_thread` to stay off the event loop)

Each call site adds one line right after `db.update_analysis(...)`.

**Tests**
- `tests/unit/test_meeting_detector.py` — 15 tests covering happy path, no-meeting, low-confidence skip, idempotency, JSON parse failure, API exception, prompt anchoring on Received date, title fallback to email subject, participants normalization, and the ISO splitter helper
- `tests/integration/test_meeting_detector_integration.py` — 1 live-Claude test against a known meeting-request email, self-skips without `ANTHROPIC_API_KEY`

**Docs**
- `docs/PROGRESS.md` Week 4 — flipped Story A to ✅ (PR #35 merged), Story B to 🔄

## How to test

```powershell
.venv/Scripts/black --check app/ tests/
.venv/Scripts/flake8 app/ tests/ --max-line-length=100
.venv/Scripts/pytest tests/ --cov=app
```

Local result: **175 passed, 92.85% total coverage**, `app/ai/meeting_detector.py` at 93%.

Manual smoke test (optional, after merge + deploy):
1. Send yourself an email like *"Let's sync next Tuesday at 3pm UK time for 30 min on Zoom"*
2. In Telegram, run `/analyze`
3. Confirm the bot still replies normally; then check the prod DB for a fresh `calendar_events` row tied to the email
4. Re-run `/analyze` and confirm **no duplicate row** is created

- [x] Unit tests added under `tests/unit/`
- [x] Integration test added (Claude API boundary)
- [ ] Manual verification steps (optional, see above)

## Checklist

- [x] PR title follows Conventional Commits (`feat:`)
- [x] Body links the issue with `Closes #36`
- [x] All public functions have type hints
- [x] All public functions have a one-line docstring
- [x] No comments restating *what* the code does
- [x] No secrets, tokens, or real credentials committed
- [x] Coverage ≥ 80% on the changed module(s) (meeting_detector 93%, overall 92.85%)
- [x] `black --check` and `flake8` pass locally
- [ ] CI is green (will verify after push)
- [x] `docs/PROGRESS.md` updated

## Notes for the reviewer

- **`CONFIDENCE_THRESHOLD = 0.6`** lives as a module constant so it's easy to tune from one place. If Claude is too eager to flag non-meetings, raise it; if it's too conservative, lower it.
- **Idempotency check** uses the presence of any `calendar_events` row for the email. That means a low-confidence run followed by a high-confidence re-run won't update. If we ever want to "upgrade" a detection, we'd need a status transition rather than skip — happy to refactor later if needed.
- **Wiring choice:** I added one line at each of the 3 call sites instead of wrapping `analyze_email`. Reason: `analyze_email` doesn't currently know the `email_id` (it just gets a dict from `db.get_unprocessed_emails`), and adding it changes the analyzer's contract for every existing test. The single-line addition at each call site is the smaller blast radius.
- **Out of scope (W4-C):** `/schedule` Telegram command, approve buttons, freebusy conflict check, `events.insert()` call against Google Calendar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)