### PR TITLE
feat: /schedule flow to create calendar events with conflict guard (W4-C)

### DIFF
--- a/app/calendar/scheduler.py
+++ b/app/calendar/scheduler.py
@@ -1,0 +1,91 @@
+"""Turn a detected `calendar_events` row into a real Google Calendar event.
+
+Testable orchestration over `app.calendar.service` (live API) + `app.database.db`,
+mirroring how `app.ai.meeting_detector.maybe_detect_meeting` composes the lower
+layers. The live I/O stays behind `service.py`; everything here is unit-tested by
+mocking `service.check_busy` / `service.insert_event`.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from app.calendar import service
+
+DEFAULT_DURATION_MINUTES = 30
+
+
+def event_window(event_row: dict) -> tuple[str, str] | None:
+    """Compute (start, end) as RFC3339 UTC for a detected event row.
+
+    Combines `event_date` + `event_time`; the end is `DEFAULT_DURATION_MINUTES`
+    after the start when `duration_minutes` is null. Returns None when the row
+    has no concrete date+time, so undated detections can't be scheduled.
+    """
+    event_date = event_row.get("event_date")
+    event_time = event_row.get("event_time")
+    if not event_date or not event_time:
+        return None
+
+    try:
+        start = datetime.fromisoformat(f"{event_date}T{event_time}")
+    except ValueError:
+        return None
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=timezone.utc)
+
+    duration = event_row.get("duration_minutes") or DEFAULT_DURATION_MINUTES
+    end = start + timedelta(minutes=duration)
+    return _to_rfc3339(start), _to_rfc3339(end)
+
+
+def _to_rfc3339(value: datetime) -> str:
+    """Format a tz-aware datetime as RFC3339 UTC with a trailing Z."""
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def build_event_body(event_row: dict) -> dict:
+    """Build the Google Calendar event resource from a detected event row.
+
+    Omits `location`/`attendees` rather than sending nulls so the API receives a
+    clean body. Raises ValueError if the row has no schedulable date+time.
+    """
+    window = event_window(event_row)
+    if window is None:
+        raise ValueError("event_row has no schedulable date/time")
+    start, end = window
+
+    body: dict = {
+        "summary": event_row.get("title") or "Untitled meeting",
+        "start": {"dateTime": start, "timeZone": "UTC"},
+        "end": {"dateTime": end, "timeZone": "UTC"},
+    }
+    if event_row.get("location"):
+        body["location"] = event_row["location"]
+
+    attendees = _parse_participants(event_row.get("participants"))
+    if attendees:
+        body["attendees"] = [{"email": email} for email in attendees]
+
+    return body
+
+
+def _parse_participants(participants: str | None) -> list[str]:
+    """Split the comma-joined participants string into a clean list of emails."""
+    if not participants:
+        return []
+    return [p.strip() for p in participants.split(",") if p.strip()]
+
+
+def has_conflict(event_row: dict) -> bool:
+    """True if the event's window overlaps any busy interval on the calendar."""
+    window = event_window(event_row)
+    if window is None:
+        return False
+    start, end = window
+    return bool(service.check_busy(start, end))
+
+
+def create_event(event_row: dict) -> str:
+    """Insert the event on the primary calendar; return the Google event id."""
+    body = build_event_body(event_row)
+    created = service.insert_event(body)
+    return created["id"]

--- a/app/database/db.py
+++ b/app/database/db.py
@@ -402,6 +402,36 @@ def get_calendar_event_by_email(email_id: int) -> list[dict]:
         conn.close()
 
 
+def get_calendar_event_by_id(event_row_id: int) -> dict | None:
+    """Return a single calendar event row by its id, or None if it doesn't exist."""
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT * FROM calendar_events WHERE id = ?",
+            (event_row_id,),
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def get_calendar_events_by_status(status: str) -> list[dict]:
+    """Return all calendar events in a given status, ordered by event date/time then id."""
+    if status not in CALENDAR_EVENT_STATUSES:
+        raise ValueError(
+            f"Invalid calendar event status {status!r}; allowed: {sorted(CALENDAR_EVENT_STATUSES)}"
+        )
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            "SELECT * FROM calendar_events WHERE status = ? ORDER BY event_date, event_time, id",
+            (status,),
+        ).fetchall()
+        return [dict(row) for row in rows]
+    finally:
+        conn.close()
+
+
 def update_calendar_event_status(
     event_row_id: int,
     status: str,

--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -11,6 +11,7 @@ from telegram.ext import Application, CallbackQueryHandler, CommandHandler, Cont
 from app.ai.analyzer import analyze_email
 from app.ai.meeting_detector import maybe_detect_meeting
 from app.ai.reply_generator import generate_replies, regenerate_one
+from app.calendar import scheduler
 from app.database import db
 from app.gmail.service import get_recent_emails as gmail_fetch_recent
 from app.gmail.service import send_reply as gmail_send_reply
@@ -37,6 +38,7 @@ WELCOME = (
     "/analyze - run AI analysis on unprocessed emails\n"
     "/inbox - show last analyzed emails\n"
     "/reply <id> - draft a reply to an email\n"
+    "/schedule - create calendar events from detected meetings\n"
     "/pause - stop push notifications\n"
     "/resume - start push notifications\n"
     "/help - show this message"
@@ -52,6 +54,7 @@ COMMANDS: list[BotCommand] = [
     BotCommand("analyze", "analyze emails with claude"),
     BotCommand("inbox", "show recently analyzed emails"),
     BotCommand("reply", "draft replies — usage: /reply <id>"),
+    BotCommand("schedule", "create calendar events from detected meetings"),
     BotCommand("pause", "pause push notifications"),
     BotCommand("resume", "resume push notifications"),
 ]
@@ -446,6 +449,105 @@ async def resume_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     await update.message.reply_text("🔔 Notifications resumed.")
 
 
+def _format_schedule_entry(event: dict) -> str:
+    """Plain-text summary of a detected event for the /schedule list."""
+    lines = [f"#{event['id']} · {event.get('title') or 'Untitled meeting'}"]
+    lines.append(f"🗓 {event.get('event_date')} {event.get('event_time')}")
+    duration = event.get("duration_minutes") or scheduler.DEFAULT_DURATION_MINUTES
+    lines.append(f"⏱ {duration} min")
+    if event.get("participants"):
+        lines.append(f"👥 {event['participants']}")
+    if event.get("location"):
+        lines.append(f"📍 {event['location']}")
+    return "\n".join(lines)
+
+
+def _build_schedule_keyboard(event_id: int) -> InlineKeyboardMarkup:
+    """Create/Skip keyboard for one detected event."""
+    return InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton("✅ Create", callback_data=f"s:create:{event_id}"),
+                InlineKeyboardButton("⏭ Skip", callback_data=f"s:skip:{event_id}"),
+            ]
+        ]
+    )
+
+
+@authorized_only
+async def schedule_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """`/schedule` — list detected meetings with a concrete date+time to create."""
+    chat = update.effective_chat
+    events = db.get_calendar_events_by_status("detected")
+    schedulable = [e for e in events if e.get("event_date") and e.get("event_time")]
+    if not schedulable:
+        await chat.send_message("No meetings to schedule.")
+        return
+    for event in schedulable:
+        await chat.send_message(
+            _format_schedule_entry(event),
+            reply_markup=_build_schedule_keyboard(event["id"]),
+        )
+
+
+@authorized_only
+async def cb_schedule_create(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Create button — block on freebusy conflict, else insert + mark created."""
+    query = update.callback_query
+    await query.answer("Checking…")
+    parsed = _parse_callback(query.data or "", prefix="s")
+    if parsed is None or parsed[0] != "create":
+        return
+    _, event_id = parsed
+    event = db.get_calendar_event_by_id(event_id)
+    if event is None:
+        await update.effective_chat.send_message("That event no longer exists.")
+        return
+    if event["status"] in ("created", "skipped"):
+        await update.effective_chat.send_message(f"Event already {event['status']}.")
+        return
+
+    if scheduler.has_conflict(event):
+        await update.effective_chat.send_message(
+            "⚠ Conflicts with an existing calendar event — not created. "
+            "Tap Skip, or free up the slot and try again."
+        )
+        return
+
+    try:
+        google_event_id = scheduler.create_event(event)
+    except Exception as exc:  # noqa: BLE001 — surface a generic failure to the user
+        logger.exception("Calendar insert failed for event=%s", event_id)
+        db.update_calendar_event_status(event_id, "failed")
+        await update.effective_chat.send_message(f"Create failed: {exc}")
+        return
+
+    db.update_calendar_event_status(event_id, "created", google_event_id=google_event_id)
+    await update.effective_chat.send_message(
+        f"✅ Event created: {event.get('title') or 'meeting'}."
+    )
+
+
+@authorized_only
+async def cb_schedule_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Skip button — mark the detected event skipped, no Calendar call."""
+    query = update.callback_query
+    await query.answer("Skipped")
+    parsed = _parse_callback(query.data or "", prefix="s")
+    if parsed is None or parsed[0] != "skip":
+        return
+    _, event_id = parsed
+    event = db.get_calendar_event_by_id(event_id)
+    if event is None:
+        await update.effective_chat.send_message("That event no longer exists.")
+        return
+    if event["status"] in ("created", "skipped"):
+        await update.effective_chat.send_message(f"Event already {event['status']}.")
+        return
+    db.update_calendar_event_status(event_id, "skipped")
+    await update.effective_chat.send_message("⏭ Skipped.")
+
+
 def register(application: Application) -> None:
     """Register all command handlers on the given Application."""
     application.add_handler(CommandHandler("start", start))
@@ -454,6 +556,7 @@ def register(application: Application) -> None:
     application.add_handler(CommandHandler("analyze", analyze))
     application.add_handler(CommandHandler("inbox", inbox))
     application.add_handler(CommandHandler("reply", reply_command))
+    application.add_handler(CommandHandler("schedule", schedule_command))
     application.add_handler(CommandHandler("pause", pause_command))
     application.add_handler(CommandHandler("resume", resume_command))
 
@@ -465,3 +568,5 @@ def register(application: Application) -> None:
     application.add_handler(CallbackQueryHandler(cb_regenerate, pattern=r"^r:regen:\d+$"))
     application.add_handler(CallbackQueryHandler(cb_notify_reply, pattern=r"^n:reply:\d+$"))
     application.add_handler(CallbackQueryHandler(cb_notify_done, pattern=r"^n:done:\d+$"))
+    application.add_handler(CallbackQueryHandler(cb_schedule_create, pattern=r"^s:create:\d+$"))
+    application.add_handler(CallbackQueryHandler(cb_schedule_skip, pattern=r"^s:skip:\d+$"))

--- a/tests/integration/test_calendar_scheduler_integration.py
+++ b/tests/integration/test_calendar_scheduler_integration.py
@@ -1,0 +1,39 @@
+"""Integration test for app.calendar.scheduler against the real Calendar API.
+
+READ-ONLY: exercises the freebusy path via `has_conflict` for a window far in the
+future. Never inserts/mutates the real calendar.
+
+Run with: pytest -m integration tests/integration/test_calendar_scheduler_integration.py
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.path.exists("token.pickle"),
+        reason="Requires authenticated token.pickle (re-auth after Calendar scope added)",
+    ),
+]
+
+
+def test_has_conflict_runs_freebusy_against_live_calendar():
+    """has_conflict resolves the row's window and queries real freebusy, returning a bool."""
+    from app.calendar import scheduler
+
+    # A window ~1 year out at an unusual minute — almost certainly free, but we
+    # only assert the call succeeds and returns a bool (no calendar mutation).
+    far_future = datetime.now(timezone.utc) + timedelta(days=365)
+    row = {
+        "id": 0,
+        "title": "Scheduler integration probe (read-only)",
+        "event_date": far_future.strftime("%Y-%m-%d"),
+        "event_time": "03:17:00",
+        "duration_minutes": 15,
+        "participants": None,
+        "location": None,
+    }
+    assert isinstance(scheduler.has_conflict(row), bool)

--- a/tests/unit/test_calendar_scheduler.py
+++ b/tests/unit/test_calendar_scheduler.py
@@ -1,0 +1,102 @@
+"""Unit tests for app.calendar.scheduler (no live Calendar calls)."""
+
+import pytest
+
+from app.calendar import scheduler
+
+
+def _row(**overrides) -> dict:
+    """A detected calendar_events row with sensible defaults, overridable per test."""
+    base = {
+        "id": 1,
+        "title": "Sync with Alice",
+        "event_date": "2026-05-19",
+        "event_time": "15:00:00",
+        "duration_minutes": 60,
+        "participants": "alice@x.com, bob@y.com",
+        "location": "Zoom",
+        "status": "detected",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_event_window_full_row():
+    start, end = scheduler.event_window(_row())
+    assert start == "2026-05-19T15:00:00Z"
+    assert end == "2026-05-19T16:00:00Z"
+
+
+def test_event_window_defaults_duration_when_null():
+    start, end = scheduler.event_window(_row(duration_minutes=None))
+    assert start == "2026-05-19T15:00:00Z"
+    assert end == "2026-05-19T15:30:00Z"  # DEFAULT_DURATION_MINUTES = 30
+
+
+def test_event_window_none_without_date_or_time():
+    assert scheduler.event_window(_row(event_date=None)) is None
+    assert scheduler.event_window(_row(event_time=None)) is None
+
+
+def test_event_window_none_on_unparseable_datetime():
+    assert scheduler.event_window(_row(event_time="not-a-time")) is None
+
+
+def test_build_event_body_full_row():
+    body = scheduler.build_event_body(_row())
+    assert body["summary"] == "Sync with Alice"
+    assert body["location"] == "Zoom"
+    assert body["start"] == {"dateTime": "2026-05-19T15:00:00Z", "timeZone": "UTC"}
+    assert body["end"] == {"dateTime": "2026-05-19T16:00:00Z", "timeZone": "UTC"}
+    assert body["attendees"] == [{"email": "alice@x.com"}, {"email": "bob@y.com"}]
+
+
+def test_build_event_body_omits_null_location_and_participants():
+    body = scheduler.build_event_body(_row(location=None, participants=None))
+    assert "location" not in body
+    assert "attendees" not in body
+    assert body["summary"] == "Sync with Alice"
+
+
+def test_build_event_body_raises_without_window():
+    with pytest.raises(ValueError, match="no schedulable date/time"):
+        scheduler.build_event_body(_row(event_time=None))
+
+
+def test_has_conflict_true_when_busy(monkeypatch):
+    monkeypatch.setattr(
+        scheduler.service,
+        "check_busy",
+        lambda *_a, **_k: [{"start": "2026-05-19T15:30:00Z", "end": "2026-05-19T16:00:00Z"}],
+    )
+    assert scheduler.has_conflict(_row()) is True
+
+
+def test_has_conflict_false_when_free(monkeypatch):
+    monkeypatch.setattr(scheduler.service, "check_busy", lambda *_a, **_k: [])
+    assert scheduler.has_conflict(_row()) is False
+
+
+def test_has_conflict_false_when_no_window(monkeypatch):
+    called = False
+
+    def _boom(*_a, **_k):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr(scheduler.service, "check_busy", _boom)
+    assert scheduler.has_conflict(_row(event_time=None)) is False
+    assert called is False  # never queries freebusy for an undated row
+
+
+def test_create_event_returns_google_event_id(monkeypatch):
+    captured = {}
+
+    def _fake_insert(body, *_a, **_k):
+        captured["body"] = body
+        return {"id": "goog_evt_99"}
+
+    monkeypatch.setattr(scheduler.service, "insert_event", _fake_insert)
+    assert scheduler.create_event(_row()) == "goog_evt_99"
+    assert captured["body"]["summary"] == "Sync with Alice"

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -347,6 +347,37 @@ def test_update_calendar_event_status_rejects_unknown_status():
         db.update_calendar_event_status(event_row, "definitely-not-real")
 
 
+def test_get_calendar_event_by_id_round_trips():
+    email_row = _make_email("cal_by_id")
+    event_row = db.insert_calendar_event(email_row, "Standup", event_date="2026-06-01")
+    got = db.get_calendar_event_by_id(event_row)
+    assert got is not None
+    assert got["id"] == event_row
+    assert got["title"] == "Standup"
+
+
+def test_get_calendar_event_by_id_returns_none_when_missing():
+    assert db.get_calendar_event_by_id(99999) is None
+
+
+def test_get_calendar_events_by_status_filters_and_orders():
+    email_row = _make_email("cal_by_status")
+    db.insert_calendar_event(email_row, "Later", event_date="2026-06-02", event_time="09:00")
+    db.insert_calendar_event(email_row, "Earlier", event_date="2026-06-01", event_time="09:00")
+    created_row = db.insert_calendar_event(email_row, "Already done")
+    db.update_calendar_event_status(created_row, "created", google_event_id="g1")
+
+    detected = db.get_calendar_events_by_status("detected")
+    assert [e["title"] for e in detected] == ["Earlier", "Later"]
+    created = db.get_calendar_events_by_status("created")
+    assert [e["title"] for e in created] == ["Already done"]
+
+
+def test_get_calendar_events_by_status_rejects_unknown_status():
+    with pytest.raises(ValueError, match="Invalid calendar event status"):
+        db.get_calendar_events_by_status("nonsense")
+
+
 def test_init_db_backfills_calendar_events_status(monkeypatch):
     """A DB created before Week 4 (calendar_events with no status column) must
     migrate cleanly when init_db runs again."""

--- a/tests/unit/test_telegram_handlers.py
+++ b/tests/unit/test_telegram_handlers.py
@@ -711,7 +711,7 @@ async def test_cb_notify_done_ignores_malformed_callback(monkeypatch, reply_cont
 
 @pytest.mark.asyncio
 async def test_set_bot_commands_registers_all_commands():
-    """All 8 user-facing commands must be sent to Telegram's set_my_commands."""
+    """All 9 user-facing commands must be sent to Telegram's set_my_commands."""
     application = MagicMock()
     application.bot.set_my_commands = AsyncMock()
 
@@ -720,7 +720,17 @@ async def test_set_bot_commands_registers_all_commands():
     application.bot.set_my_commands.assert_awaited_once()
     sent = application.bot.set_my_commands.await_args.args[0]
     names = {c.command for c in sent}
-    assert names == {"start", "help", "unread", "analyze", "inbox", "reply", "pause", "resume"}
+    assert names == {
+        "start",
+        "help",
+        "unread",
+        "analyze",
+        "inbox",
+        "reply",
+        "schedule",
+        "pause",
+        "resume",
+    }
     # Every command needs a non-empty description so the popup row isn't blank.
     assert all(c.description for c in sent)
 
@@ -755,3 +765,163 @@ async def test_unread_drops_unauthorized(monkeypatch):
     await handlers.unread(update, None)
     assert fetch_called is False
     update.message.reply_text.assert_not_awaited()
+
+
+def _detected_event(**overrides) -> dict:
+    """A detected calendar_events row with a concrete date+time."""
+    base = {
+        "id": 3,
+        "title": "Sync with Alice",
+        "event_date": "2026-05-19",
+        "event_time": "15:00:00",
+        "duration_minutes": 60,
+        "participants": "alice@x.com",
+        "location": "Zoom",
+        "status": "detected",
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_schedule_command_lists_dated_detected_and_hides_undated(
+    monkeypatch, authorized_update
+):
+    events = [
+        _detected_event(id=1, title="Has time"),
+        _detected_event(id=2, title="No time", event_time=None),
+        _detected_event(id=3, title="No date", event_date=None),
+    ]
+    monkeypatch.setattr(handlers.db, "get_calendar_events_by_status", lambda _: events)
+    await handlers.schedule_command(authorized_update, None)
+
+    texts = _all_reply_texts(authorized_update)
+    assert "Has time" in texts
+    assert "No time" not in texts
+    assert "No date" not in texts
+    # Exactly one message per schedulable event.
+    assert authorized_update.effective_chat.send_message.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_schedule_command_empty(monkeypatch, authorized_update):
+    monkeypatch.setattr(handlers.db, "get_calendar_events_by_status", lambda _: [])
+    await handlers.schedule_command(authorized_update, None)
+    assert "No meetings to schedule." in _all_reply_texts(authorized_update)
+
+
+@pytest.mark.asyncio
+async def test_cb_schedule_create_free_window_creates(monkeypatch, reply_context):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+    monkeypatch.setattr(handlers.db, "get_calendar_event_by_id", lambda _: _detected_event())
+    monkeypatch.setattr(handlers.scheduler, "has_conflict", lambda _: False)
+    monkeypatch.setattr(handlers.scheduler, "create_event", lambda _: "goog_evt_99")
+    status_calls: list[tuple] = []
+    monkeypatch.setattr(
+        handlers.db,
+        "update_calendar_event_status",
+        lambda eid, status, **kw: status_calls.append((eid, status, kw)),
+    )
+
+    update = _make_callback_update("s:create:3")
+    await handlers.cb_schedule_create(update, reply_context)
+
+    assert status_calls == [(3, "created", {"google_event_id": "goog_evt_99"})]
+    assert "Event created" in update.effective_chat.send_message.await_args_list[-1].args[0]
+
+
+@pytest.mark.asyncio
+async def test_cb_schedule_create_conflict_blocks(monkeypatch, reply_context):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+    monkeypatch.setattr(handlers.db, "get_calendar_event_by_id", lambda _: _detected_event())
+    monkeypatch.setattr(handlers.scheduler, "has_conflict", lambda _: True)
+
+    create_called = False
+
+    def _boom(_):
+        nonlocal create_called
+        create_called = True
+        return "x"
+
+    monkeypatch.setattr(handlers.scheduler, "create_event", _boom)
+    status_calls: list[tuple] = []
+    monkeypatch.setattr(
+        handlers.db,
+        "update_calendar_event_status",
+        lambda *a, **k: status_calls.append((a, k)),
+    )
+
+    update = _make_callback_update("s:create:3")
+    await handlers.cb_schedule_create(update, reply_context)
+
+    assert create_called is False
+    assert status_calls == []  # status stays 'detected'
+    assert "Conflicts" in update.effective_chat.send_message.await_args_list[-1].args[0]
+
+
+@pytest.mark.asyncio
+async def test_cb_schedule_create_api_failure_marks_failed(monkeypatch, reply_context):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+    monkeypatch.setattr(handlers.db, "get_calendar_event_by_id", lambda _: _detected_event())
+    monkeypatch.setattr(handlers.scheduler, "has_conflict", lambda _: False)
+
+    def boom(_):
+        raise RuntimeError("calendar 500")
+
+    monkeypatch.setattr(handlers.scheduler, "create_event", boom)
+    status_calls: list[tuple] = []
+    monkeypatch.setattr(
+        handlers.db,
+        "update_calendar_event_status",
+        lambda eid, status, **kw: status_calls.append((eid, status, kw)),
+    )
+
+    update = _make_callback_update("s:create:3")
+    await handlers.cb_schedule_create(update, reply_context)
+
+    assert status_calls == [(3, "failed", {})]
+    assert "Create failed" in update.effective_chat.send_message.await_args_list[-1].args[0]
+
+
+@pytest.mark.asyncio
+async def test_cb_schedule_create_idempotent_when_already_created(monkeypatch, reply_context):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+    monkeypatch.setattr(
+        handlers.db, "get_calendar_event_by_id", lambda _: _detected_event(status="created")
+    )
+    create_called = False
+
+    def _boom(_):
+        nonlocal create_called
+        create_called = True
+        return "x"
+
+    monkeypatch.setattr(handlers.scheduler, "create_event", _boom)
+    update = _make_callback_update("s:create:3")
+    await handlers.cb_schedule_create(update, reply_context)
+
+    assert create_called is False
+    assert "already created" in update.effective_chat.send_message.await_args_list[-1].args[0]
+
+
+@pytest.mark.asyncio
+async def test_cb_schedule_skip_marks_skipped(monkeypatch, reply_context):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+    monkeypatch.setattr(handlers.db, "get_calendar_event_by_id", lambda _: _detected_event())
+    status_calls: list[tuple] = []
+    monkeypatch.setattr(
+        handlers.db,
+        "update_calendar_event_status",
+        lambda eid, status, **kw: status_calls.append((eid, status, kw)),
+    )
+
+    update = _make_callback_update("s:skip:3")
+    await handlers.cb_schedule_skip(update, reply_context)
+
+    assert status_calls == [(3, "skipped", {})]
+    assert "Skipped" in update.effective_chat.send_message.await_args_list[-1].args[0]


### PR DESCRIPTION
Closes #38

## Summary
- `/schedule` (list-only) shows detected meetings that have a concrete date+time, each with ✅ Create / ⏭ Skip; undated detections are hidden, empty state replies `No meetings to schedule.`
- ✅ Create runs an authoritative free/busy check at tap time and **blocks on conflict** (no event created, row stays `detected`); on a free window it inserts the Google Calendar event and marks the row `created` with `google_event_id`. Google API errors transition the row to `failed`; already `created`/`skipped` rows are guarded against duplicates.
- New `app/calendar/scheduler.py` orchestration (`event_window`, `build_event_body`, `has_conflict`, `create_event`, tunable `DEFAULT_DURATION_MINUTES`); new DB helpers `get_calendar_event_by_id` + `get_calendar_events_by_status`; `BotCommand`/`WELCOME` updated.

## Test plan
- [x] All tests pass locally (197 passed, 92.67% coverage)
- [x] black + flake8 clean
- [x] Unit: scheduler (window/body/conflict/create), `/schedule` + 3 callbacks, 2 new DB helpers
- [x] Read-only freebusy integration test (self-skips without `token.pickle`, no calendar mutation)