### PR TITLE
feat: agentic /agent command — Claude tool-use loop with approve-before-act (W5-A)

### DIFF
--- a/app/ai/__init__.py
+++ b/app/ai/__init__.py
@@ -1,0 +1,5 @@
+"""AI package — shared config for the Claude-backed modules."""
+
+# Single source of truth for the model id. analyzer/meeting_detector/reply_generator
+# still hardcode this string; centralizing them here is a tracked follow-up.
+MODEL = "claude-sonnet-4-20250514"

--- a/app/ai/agent.py
+++ b/app/ai/agent.py
@@ -1,0 +1,330 @@
+"""Agentic /agent flow: a Claude tool-use loop over the app's existing capabilities.
+
+Read-only tools execute live so the model reasons over real inbox/calendar data;
+mutating tools (send a reply, create a calendar event) are NEVER run inside the
+loop — they're queued as pending actions for explicit user approval, preserving
+the approve-before-act model already used by /reply and /schedule.
+"""
+
+import json
+import os
+
+from anthropic import Anthropic
+
+from app.ai import MODEL
+from app.ai.analyzer import analyze_email
+from app.ai.reply_generator import regenerate_one
+from app.calendar import scheduler
+from app.calendar import service as calendar_service
+from app.database import db
+from app.gmail.service import send_reply as gmail_send_reply
+
+_client: Anthropic | None = None
+
+MAX_TOKENS = 1024
+MAX_ITERATIONS = 5
+
+SYSTEM_PROMPT = (
+    "You are an email assistant agent operating over the user's Gmail and Google "
+    "Calendar. Use the read-only tools to gather what you need, then propose any "
+    "send-reply or create-event actions. Those actions require the user's approval "
+    "and will not run until approved, so include the full reply body or event "
+    "details when you call them. Reference emails by their numeric id. Be concise."
+)
+
+MUTATING_TOOLS = {"send_reply", "create_calendar_event"}
+
+
+def _get_client() -> Anthropic:
+    """Lazy Anthropic client so the API key is read after load_dotenv()."""
+    global _client
+    if _client is None:
+        _client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+    return _client
+
+
+# --- Read-only tool implementations (safe to run automatically) ---------------
+
+
+def _tool_list_recent_emails(limit: int = 10) -> list[dict]:
+    """Return a compact list of recent emails for the model to reason over."""
+    rows = db.get_recent_emails(limit=limit)
+    return [
+        {
+            "id": r.get("id"),
+            "sender": r.get("sender"),
+            "subject": r.get("subject"),
+            "snippet": r.get("snippet"),
+            "category": r.get("category"),
+            "urgency_score": r.get("urgency_score"),
+        }
+        for r in rows
+    ]
+
+
+def _tool_get_email(email_id: int) -> dict:
+    """Return the full stored email row, or an error marker if it's missing."""
+    email = db.get_email_by_row_id(email_id)
+    return email or {"error": f"no email with id {email_id}"}
+
+
+def _tool_analyze_email(email_id: int) -> dict:
+    """Run Claude analysis on a stored email and return the structured result."""
+    email = db.get_email_by_row_id(email_id)
+    if not email:
+        return {"error": f"no email with id {email_id}"}
+    return analyze_email(email) or {"error": "analysis failed"}
+
+
+def _tool_check_calendar_availability(start_iso: str, end_iso: str) -> dict:
+    """Return busy intervals in the window and whether it's free."""
+    busy = calendar_service.check_busy(start_iso, end_iso)
+    return {"busy": busy, "free": not busy}
+
+
+def _tool_draft_reply(email_id: int, tone: str = "professional") -> dict:
+    """Generate a single reply draft so the model can propose sending it."""
+    email = db.get_email_by_row_id(email_id)
+    if not email:
+        return {"error": f"no email with id {email_id}"}
+    text = regenerate_one(email, tone)
+    if not text:
+        return {"error": "draft generation failed"}
+    return {"tone": tone, "text": text}
+
+
+_READ_ONLY_DISPATCH = {
+    "list_recent_emails": _tool_list_recent_emails,
+    "get_email": _tool_get_email,
+    "analyze_email": _tool_analyze_email,
+    "check_calendar_availability": _tool_check_calendar_availability,
+    "draft_reply": _tool_draft_reply,
+}
+
+
+TOOLS = [
+    {
+        "name": "list_recent_emails",
+        "description": "List recent emails (id, sender, subject, snippet, category, urgency).",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer", "description": "How many emails (default 10)."}
+            },
+        },
+    },
+    {
+        "name": "get_email",
+        "description": "Get the full stored email by its numeric id.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"email_id": {"type": "integer"}},
+            "required": ["email_id"],
+        },
+    },
+    {
+        "name": "analyze_email",
+        "description": "Run AI analysis (summary, category, urgency, action) on an email by id.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"email_id": {"type": "integer"}},
+            "required": ["email_id"],
+        },
+    },
+    {
+        "name": "check_calendar_availability",
+        "description": "Check busy/free for a time window. Times are RFC3339 UTC (…Z).",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "start_iso": {"type": "string"},
+                "end_iso": {"type": "string"},
+            },
+            "required": ["start_iso", "end_iso"],
+        },
+    },
+    {
+        "name": "draft_reply",
+        "description": "Generate a reply draft for an email so you can propose sending it.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "email_id": {"type": "integer"},
+                "tone": {
+                    "type": "string",
+                    "description": "professional | friendly | brief (default professional).",
+                },
+            },
+            "required": ["email_id"],
+        },
+    },
+    {
+        "name": "send_reply",
+        "description": (
+            "Propose sending a reply to an email. Requires user approval before it runs."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "email_id": {"type": "integer"},
+                "body": {"type": "string", "description": "The full reply text to send."},
+            },
+            "required": ["email_id", "body"],
+        },
+    },
+    {
+        "name": "create_calendar_event",
+        "description": (
+            "Propose creating a calendar event. Requires user approval. "
+            "start_iso is RFC3339 UTC (…Z)."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string"},
+                "start_iso": {"type": "string"},
+                "duration_minutes": {"type": "integer", "description": "Default 30."},
+                "location": {"type": "string"},
+                "participants": {"type": "string", "description": "Comma-separated emails."},
+            },
+            "required": ["title", "start_iso"],
+        },
+    },
+]
+
+
+def _collect_text(content: list) -> str:
+    """Join the text blocks of a response's content list."""
+    parts = []
+    for block in content:
+        if getattr(block, "type", None) == "text":
+            parts.append(block.text)
+    return "\n".join(parts).strip()
+
+
+def _handle_tool_use(block, pending: list[dict]) -> str:
+    """Execute a read-only tool, or queue a mutating one; return the tool_result text."""
+    name = getattr(block, "name", "")
+    args = getattr(block, "input", None) or {}
+    if name in MUTATING_TOOLS:
+        pending.append({"name": name, "input": args})
+        return "PENDING_APPROVAL: queued for user approval."
+    fn = _READ_ONLY_DISPATCH.get(name)
+    if fn is None:
+        return f"ERROR: unknown tool {name!r}"
+    try:
+        return json.dumps(fn(**args), default=str)
+    except Exception as exc:  # noqa: BLE001 — feed the error back to the model, don't crash
+        return f"ERROR: tool {name} failed: {exc}"
+
+
+def run_agent(instruction: str) -> tuple[str, list[dict]]:
+    """Run the tool-use loop for one instruction.
+
+    Returns (final_text, pending_actions). pending_actions is the ordered list of
+    mutating tool calls the model proposed but that were NOT executed — the caller
+    must get user approval and pass each to execute_action.
+    """
+    client = _get_client()
+    messages: list[dict] = [{"role": "user", "content": instruction}]
+    pending: list[dict] = []
+    final_text = ""
+
+    for _ in range(MAX_ITERATIONS):
+        response = client.messages.create(
+            model=MODEL,
+            max_tokens=MAX_TOKENS,
+            system=SYSTEM_PROMPT,
+            tools=TOOLS,
+            messages=messages,
+        )
+        text = _collect_text(response.content)
+        if text:
+            final_text = text
+
+        if getattr(response, "stop_reason", None) != "tool_use":
+            break
+
+        messages.append({"role": "assistant", "content": response.content})
+        tool_results = [
+            {
+                "type": "tool_result",
+                "tool_use_id": block.id,
+                "content": _handle_tool_use(block, pending),
+            }
+            for block in response.content
+            if getattr(block, "type", None) == "tool_use"
+        ]
+        messages.append({"role": "user", "content": tool_results})
+
+    return final_text.strip(), pending
+
+
+# --- Mutating action execution (run only after user approval) ------------------
+
+
+def describe_action(action: dict) -> str:
+    """One-line human summary of a queued action for the approval prompt."""
+    name = action.get("name")
+    args = action.get("input") or {}
+    if name == "send_reply":
+        preview = (args.get("body") or "").replace("\n", " ")
+        if len(preview) > 120:
+            preview = preview[:117] + "…"
+        return f"Send reply to email {args.get('email_id')}: {preview}"
+    if name == "create_calendar_event":
+        return (
+            f"Create event '{args.get('title')}' at {args.get('start_iso')} "
+            f"({args.get('duration_minutes') or 30} min)"
+        )
+    return f"{name} {args}"
+
+
+def execute_action(action: dict) -> str:
+    """Run a single approved mutating action; return a human-readable result."""
+    name = action.get("name")
+    args = action.get("input") or {}
+    if name == "send_reply":
+        return _exec_send_reply(**args)
+    if name == "create_calendar_event":
+        return _exec_create_calendar_event(**args)
+    return f"Unknown action {name!r}"
+
+
+def _exec_send_reply(email_id: int, body: str) -> str:
+    """Send a reply to a stored email via Gmail."""
+    email = db.get_email_by_row_id(email_id)
+    if not email:
+        return f"Email {email_id} not found."
+    gmail_send_reply(email["thread_id"], email["gmail_message_id"], body)
+    return f"Reply sent to email {email_id}."
+
+
+def _exec_create_calendar_event(
+    title: str,
+    start_iso: str,
+    duration_minutes: int | None = None,
+    location: str | None = None,
+    participants: str | None = None,
+) -> str:
+    """Create a Google Calendar event from agent-supplied fields."""
+    event_date, event_time = _split_iso(start_iso)
+    event_row = {
+        "title": title,
+        "event_date": event_date,
+        "event_time": event_time,
+        "duration_minutes": duration_minutes,
+        "location": location,
+        "participants": participants,
+    }
+    google_event_id = scheduler.create_event(event_row)
+    return f"Calendar event created: {title} ({google_event_id})."
+
+
+def _split_iso(iso: str) -> tuple[str | None, str | None]:
+    """Split an RFC3339/ISO datetime into (date, time) parts for scheduler.create_event."""
+    cleaned = (iso or "").replace("Z", "").strip()
+    if "T" not in cleaned:
+        return (cleaned or None), None
+    date_part, _, time_part = cleaned.partition("T")
+    return (date_part or None), (time_part or None)

--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -8,6 +8,7 @@ from telegram import BotCommand, InlineKeyboardButton, InlineKeyboardMarkup, Upd
 from telegram.constants import ChatAction, ParseMode
 from telegram.ext import Application, CallbackQueryHandler, CommandHandler, ContextTypes
 
+from app.ai import agent
 from app.ai.analyzer import analyze_email
 from app.ai.meeting_detector import maybe_detect_meeting
 from app.ai.reply_generator import generate_replies, regenerate_one
@@ -39,6 +40,7 @@ WELCOME = (
     "/inbox - show last analyzed emails\n"
     "/reply <id> - draft a reply to an email\n"
     "/schedule - create calendar events from detected meetings\n"
+    "/agent <text> - run a natural-language request through the agent\n"
     "/pause - stop push notifications\n"
     "/resume - start push notifications\n"
     "/help - show this message"
@@ -55,6 +57,7 @@ COMMANDS: list[BotCommand] = [
     BotCommand("inbox", "show recently analyzed emails"),
     BotCommand("reply", "draft replies — usage: /reply <id>"),
     BotCommand("schedule", "create calendar events from detected meetings"),
+    BotCommand("agent", "run a natural-language request through the agent"),
     BotCommand("pause", "pause push notifications"),
     BotCommand("resume", "resume push notifications"),
 ]
@@ -548,6 +551,73 @@ async def cb_schedule_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     await update.effective_chat.send_message("⏭ Skipped.")
 
 
+@authorized_only
+async def agent_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """`/agent <instruction>` — run a natural-language request through the agent."""
+    chat = update.effective_chat
+    instruction = " ".join(context.args or []).strip()
+    if not instruction:
+        await chat.send_message("Usage: /agent <what you want done>")
+        return
+
+    await _typing(update)
+    await chat.send_message("🤖 Working on it…")
+    await _typing(update)
+    try:
+        text, pending = agent.run_agent(instruction)
+    except Exception as exc:  # noqa: BLE001 — surface a generic failure to the user
+        logger.exception("Agent run failed")
+        await chat.send_message(f"Agent failed: {exc}")
+        return
+
+    if not pending:
+        await chat.send_message(text or "Done — nothing to do.")
+        return
+
+    context.user_data["agent_pending"] = pending
+    lines = ["Proposed actions (approve to run):"]
+    lines += [f"{i}. {agent.describe_action(a)}" for i, a in enumerate(pending, 1)]
+    if text:
+        lines += ["", text]
+    keyboard = InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton("✅ Approve", callback_data="a:approve"),
+                InlineKeyboardButton("✖ Cancel", callback_data="a:cancel"),
+            ]
+        ]
+    )
+    await chat.send_message("\n".join(lines), reply_markup=keyboard)
+
+
+@authorized_only
+async def cb_agent_approve(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Approve — execute every queued agent action in order, report each result."""
+    query = update.callback_query
+    await query.answer("Running…")
+    pending = context.user_data.pop("agent_pending", None)
+    if not pending:
+        await update.effective_chat.send_message("No pending actions.")
+        return
+    results = []
+    for action in pending:
+        try:
+            results.append(f"✅ {agent.execute_action(action)}")
+        except Exception as exc:  # noqa: BLE001 — one failure shouldn't abort the rest
+            logger.exception("Agent action failed: %s", action.get("name"))
+            results.append(f"⚠ {action.get('name')} failed: {exc}")
+    await update.effective_chat.send_message("\n".join(results))
+
+
+@authorized_only
+async def cb_agent_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Cancel — discard the queued agent actions without running anything."""
+    query = update.callback_query
+    await query.answer("Cancelled")
+    context.user_data.pop("agent_pending", None)
+    await update.effective_chat.send_message("✖ Cancelled — nothing was done.")
+
+
 def register(application: Application) -> None:
     """Register all command handlers on the given Application."""
     application.add_handler(CommandHandler("start", start))
@@ -557,6 +627,7 @@ def register(application: Application) -> None:
     application.add_handler(CommandHandler("inbox", inbox))
     application.add_handler(CommandHandler("reply", reply_command))
     application.add_handler(CommandHandler("schedule", schedule_command))
+    application.add_handler(CommandHandler("agent", agent_command))
     application.add_handler(CommandHandler("pause", pause_command))
     application.add_handler(CommandHandler("resume", resume_command))
 
@@ -570,3 +641,5 @@ def register(application: Application) -> None:
     application.add_handler(CallbackQueryHandler(cb_notify_done, pattern=r"^n:done:\d+$"))
     application.add_handler(CallbackQueryHandler(cb_schedule_create, pattern=r"^s:create:\d+$"))
     application.add_handler(CallbackQueryHandler(cb_schedule_skip, pattern=r"^s:skip:\d+$"))
+    application.add_handler(CallbackQueryHandler(cb_agent_approve, pattern=r"^a:approve$"))
+    application.add_handler(CallbackQueryHandler(cb_agent_cancel, pattern=r"^a:cancel$"))

--- a/tests/integration/test_agent_integration.py
+++ b/tests/integration/test_agent_integration.py
@@ -1,0 +1,34 @@
+"""Integration test for app.ai.agent against the real Claude API.
+
+Run with: pytest -m integration tests/integration/test_agent_integration.py
+"""
+
+import os
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.getenv("ANTHROPIC_API_KEY"),
+        reason="Requires ANTHROPIC_API_KEY for a live Claude call",
+    ),
+]
+
+
+def test_agent_invokes_a_tool_on_a_clear_instruction():
+    """A 'list my recent emails' instruction should make the model call a tool."""
+    from app.ai import agent
+
+    client = agent._get_client()
+    response = client.messages.create(
+        model=agent.MODEL,
+        max_tokens=agent.MAX_TOKENS,
+        system=agent.SYSTEM_PROMPT,
+        tools=agent.TOOLS,
+        messages=[{"role": "user", "content": "List my 3 most recent emails."}],
+    )
+
+    assert response.stop_reason == "tool_use"
+    tool_names = [b.name for b in response.content if getattr(b, "type", None) == "tool_use"]
+    assert "list_recent_emails" in tool_names

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -1,0 +1,217 @@
+"""Unit tests for app.ai.agent — tool-use loop with mocked Anthropic client."""
+
+from types import SimpleNamespace
+
+from app.ai import agent
+
+
+def _text(text: str) -> SimpleNamespace:
+    return SimpleNamespace(type="text", text=text)
+
+
+def _tool(tool_id: str, name: str, tool_input: dict) -> SimpleNamespace:
+    return SimpleNamespace(type="tool_use", id=tool_id, name=name, input=tool_input)
+
+
+def _response(stop_reason: str, content: list) -> SimpleNamespace:
+    return SimpleNamespace(stop_reason=stop_reason, content=content)
+
+
+class _FakeMessages:
+    def __init__(self, responses: list, calls: list):
+        self._responses = responses
+        self.calls = calls
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return self._responses.pop(0)
+
+
+class _FakeClient:
+    def __init__(self, responses: list):
+        self.calls: list = []
+        self.messages = _FakeMessages(list(responses), self.calls)
+
+
+def _install(monkeypatch, responses: list) -> _FakeClient:
+    client = _FakeClient(responses)
+    monkeypatch.setattr(agent, "_get_client", lambda: client)
+    return client
+
+
+def test_read_only_tool_executes_and_feeds_result_back(monkeypatch):
+    monkeypatch.setattr(
+        agent.db,
+        "get_recent_emails",
+        lambda limit: [{"id": 1, "sender": "a@a", "subject": "Hi", "snippet": "x"}],
+    )
+    client = _install(
+        monkeypatch,
+        [
+            _response("tool_use", [_tool("t1", "list_recent_emails", {"limit": 3})]),
+            _response("end_turn", [_text("Here are your emails.")]),
+        ],
+    )
+
+    text, pending = agent.run_agent("list my emails")
+
+    assert text == "Here are your emails."
+    assert pending == []
+    assert len(client.calls) == 2
+    # The second call carried the tool_result back to the model.
+    fed_back = client.calls[1]["messages"][-1]["content"][0]
+    assert fed_back["type"] == "tool_result"
+    assert '"subject": "Hi"' in fed_back["content"]
+
+
+def test_mutating_tool_is_queued_not_executed(monkeypatch):
+    sent = []
+    monkeypatch.setattr(agent, "gmail_send_reply", lambda *a, **k: sent.append(a))
+    _install(
+        monkeypatch,
+        [
+            _response("tool_use", [_tool("t1", "send_reply", {"email_id": 5, "body": "Yes"})]),
+            _response("end_turn", [_text("Proposed a reply.")]),
+        ],
+    )
+
+    text, pending = agent.run_agent("reply yes to 5")
+
+    assert sent == []  # nothing sent inside the loop
+    assert pending == [{"name": "send_reply", "input": {"email_id": 5, "body": "Yes"}}]
+    assert text == "Proposed a reply."
+
+
+def test_clean_termination_no_tools(monkeypatch):
+    client = _install(monkeypatch, [_response("end_turn", [_text("Nothing to do.")])])
+    text, pending = agent.run_agent("hi")
+    assert text == "Nothing to do."
+    assert pending == []
+    assert len(client.calls) == 1
+
+
+def test_iteration_cap_stops_runaway_loop(monkeypatch):
+    monkeypatch.setattr(agent.db, "get_recent_emails", lambda limit: [])
+
+    class _Looping:
+        def __init__(self):
+            self.calls: list = []
+            self.messages = self
+
+        def create(self, **kwargs):
+            self.calls.append(kwargs)
+            return _response("tool_use", [_tool("t", "list_recent_emails", {})])
+
+    client = _Looping()
+    monkeypatch.setattr(agent, "_get_client", lambda: client)
+
+    text, pending = agent.run_agent("loop forever")
+
+    assert len(client.calls) == agent.MAX_ITERATIONS
+    assert pending == []
+
+
+def test_unknown_tool_returns_error_result(monkeypatch):
+    client = _install(
+        monkeypatch,
+        [
+            _response("tool_use", [_tool("t1", "no_such_tool", {})]),
+            _response("end_turn", [_text("done")]),
+        ],
+    )
+    text, pending = agent.run_agent("do something weird")
+    fed_back = client.calls[1]["messages"][-1]["content"][0]["content"]
+    assert fed_back.startswith("ERROR: unknown tool")
+    assert pending == []
+    assert text == "done"
+
+
+def test_tool_exception_returns_error_result(monkeypatch):
+    def boom(_):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(agent.db, "get_email_by_row_id", boom)
+    client = _install(
+        monkeypatch,
+        [
+            _response("tool_use", [_tool("t1", "get_email", {"email_id": 1})]),
+            _response("end_turn", [_text("ok")]),
+        ],
+    )
+    agent.run_agent("get email 1")
+    fed_back = client.calls[1]["messages"][-1]["content"][0]["content"]
+    assert fed_back.startswith("ERROR: tool get_email failed")
+
+
+def test_draft_reply_is_read_only(monkeypatch):
+    monkeypatch.setattr(agent.db, "get_email_by_row_id", lambda _: {"id": 5, "sender": "a@a"})
+    monkeypatch.setattr(agent, "regenerate_one", lambda email, tone: "Draft text here.")
+    client = _install(
+        monkeypatch,
+        [
+            _response("tool_use", [_tool("t1", "draft_reply", {"email_id": 5})]),
+            _response("end_turn", [_text("Here's a draft.")]),
+        ],
+    )
+    text, pending = agent.run_agent("draft a reply to 5")
+    assert pending == []  # drafting does not require approval
+    fed_back = client.calls[1]["messages"][-1]["content"][0]["content"]
+    assert "Draft text here." in fed_back
+
+
+def test_execute_action_send_reply(monkeypatch):
+    monkeypatch.setattr(
+        agent.db, "get_email_by_row_id", lambda _: {"thread_id": "th", "gmail_message_id": "gm"}
+    )
+    sent = []
+    monkeypatch.setattr(agent, "gmail_send_reply", lambda t, m, b: sent.append((t, m, b)))
+
+    result = agent.execute_action({"name": "send_reply", "input": {"email_id": 5, "body": "Hi"}})
+
+    assert sent == [("th", "gm", "Hi")]
+    assert "Reply sent to email 5" in result
+
+
+def test_execute_action_send_reply_missing_email(monkeypatch):
+    monkeypatch.setattr(agent.db, "get_email_by_row_id", lambda _: None)
+    result = agent.execute_action({"name": "send_reply", "input": {"email_id": 9, "body": "x"}})
+    assert "not found" in result
+
+
+def test_execute_action_create_calendar_event(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        agent.scheduler, "create_event", lambda row: captured.update(row) or "gid123"
+    )
+    result = agent.execute_action(
+        {
+            "name": "create_calendar_event",
+            "input": {
+                "title": "Sync",
+                "start_iso": "2026-05-25T15:00:00Z",
+                "duration_minutes": 45,
+            },
+        }
+    )
+    assert captured["event_date"] == "2026-05-25"
+    assert captured["event_time"] == "15:00:00"
+    assert captured["duration_minutes"] == 45
+    assert "Calendar event created: Sync (gid123)" in result
+
+
+def test_execute_action_unknown():
+    assert "Unknown action" in agent.execute_action({"name": "frobnicate", "input": {}})
+
+
+def test_describe_action_summaries():
+    send = agent.describe_action(
+        {"name": "send_reply", "input": {"email_id": 5, "body": "Sounds good"}}
+    )
+    assert "email 5" in send and "Sounds good" in send
+    event = agent.describe_action(
+        {
+            "name": "create_calendar_event",
+            "input": {"title": "Sync", "start_iso": "2026-05-25T15:00:00Z"},
+        }
+    )
+    assert "Sync" in event and "2026-05-25T15:00:00Z" in event

--- a/tests/unit/test_telegram_handlers.py
+++ b/tests/unit/test_telegram_handlers.py
@@ -728,6 +728,7 @@ async def test_set_bot_commands_registers_all_commands():
         "inbox",
         "reply",
         "schedule",
+        "agent",
         "pause",
         "resume",
     }
@@ -925,3 +926,100 @@ async def test_cb_schedule_skip_marks_skipped(monkeypatch, reply_context):
 
     assert status_calls == [(3, "skipped", {})]
     assert "Skipped" in update.effective_chat.send_message.await_args_list[-1].args[0]
+
+
+@pytest.mark.asyncio
+async def test_agent_command_empty_instruction_shows_usage(authorized_update, reply_context):
+    reply_context.args = []
+    await handlers.agent_command(authorized_update, reply_context)
+    assert "Usage: /agent" in _all_reply_texts(authorized_update)
+
+
+@pytest.mark.asyncio
+async def test_agent_command_text_only_no_pending(monkeypatch, authorized_update, reply_context):
+    monkeypatch.setattr(handlers.agent, "run_agent", lambda instr: ("Here is your summary.", []))
+    reply_context.args = ["summarize", "my", "unread"]
+    await handlers.agent_command(authorized_update, reply_context)
+
+    assert "Here is your summary." in _all_reply_texts(authorized_update)
+    assert "agent_pending" not in reply_context.user_data
+
+
+@pytest.mark.asyncio
+async def test_agent_command_with_pending_shows_keyboard_and_stores(
+    monkeypatch, authorized_update, reply_context
+):
+    pending = [{"name": "send_reply", "input": {"email_id": 5, "body": "Yes"}}]
+    monkeypatch.setattr(handlers.agent, "run_agent", lambda instr: ("Proposed.", pending))
+    monkeypatch.setattr(handlers.agent, "describe_action", lambda a: "Send reply to email 5")
+    reply_context.args = ["reply", "to", "5"]
+    await handlers.agent_command(authorized_update, reply_context)
+
+    assert reply_context.user_data["agent_pending"] == pending
+    calls = authorized_update.effective_chat.send_message.await_args_list
+    assert any("reply_markup" in c.kwargs for c in calls)
+    assert "Proposed actions" in _all_reply_texts(authorized_update)
+
+
+@pytest.mark.asyncio
+async def test_agent_command_handles_run_failure(monkeypatch, authorized_update, reply_context):
+    def boom(_):
+        raise RuntimeError("api down")
+
+    monkeypatch.setattr(handlers.agent, "run_agent", boom)
+    reply_context.args = ["do", "stuff"]
+    await handlers.agent_command(authorized_update, reply_context)
+    assert "Agent failed" in _all_reply_texts(authorized_update)
+
+
+@pytest.mark.asyncio
+async def test_cb_agent_approve_executes_queued_actions(monkeypatch, reply_context):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+    executed: list = []
+    monkeypatch.setattr(handlers.agent, "execute_action", lambda a: executed.append(a) or "did it")
+    reply_context.user_data = {
+        "agent_pending": [{"name": "send_reply", "input": {"email_id": 5, "body": "Yes"}}]
+    }
+    update = _make_callback_update("a:approve")
+    await handlers.cb_agent_approve(update, reply_context)
+
+    assert executed == [{"name": "send_reply", "input": {"email_id": 5, "body": "Yes"}}]
+    assert "did it" in update.effective_chat.send_message.await_args_list[-1].args[0]
+    assert "agent_pending" not in reply_context.user_data
+
+
+@pytest.mark.asyncio
+async def test_cb_agent_approve_no_pending(monkeypatch, reply_context):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+    reply_context.user_data = {}
+    update = _make_callback_update("a:approve")
+    await handlers.cb_agent_approve(update, reply_context)
+    assert "No pending actions" in update.effective_chat.send_message.await_args_list[-1].args[0]
+
+
+@pytest.mark.asyncio
+async def test_cb_agent_approve_reports_action_failure(monkeypatch, reply_context):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+
+    def boom(_):
+        raise RuntimeError("send fail")
+
+    monkeypatch.setattr(handlers.agent, "execute_action", boom)
+    reply_context.user_data = {"agent_pending": [{"name": "send_reply", "input": {}}]}
+    update = _make_callback_update("a:approve")
+    await handlers.cb_agent_approve(update, reply_context)
+    assert "failed" in update.effective_chat.send_message.await_args_list[-1].args[0]
+
+
+@pytest.mark.asyncio
+async def test_cb_agent_cancel_discards(monkeypatch, reply_context):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+    reply_context.user_data = {"agent_pending": [{"name": "send_reply", "input": {}}]}
+    update = _make_callback_update("a:cancel")
+    await handlers.cb_agent_cancel(update, reply_context)
+    assert "agent_pending" not in reply_context.user_data
+    assert "Cancelled" in update.effective_chat.send_message.await_args_list[-1].args[0]


### PR DESCRIPTION
Closes #40

## Summary
- New `app/ai/agent.py`: a native Anthropic tool-use loop. Read-only tools (`list_recent_emails`, `get_email`, `analyze_email`, `check_calendar_availability`, `draft_reply`) execute live so the model reasons over real inbox/calendar data; mutating tools (`send_reply`, `create_calendar_event`) are queued as pending actions and **never run inside the loop**.
- `/agent <instruction>` command runs the loop; if it proposes actions, the bot shows a summary + ✅ Approve / ✖ Cancel (callback prefix `a`); approval executes the queued actions in order. Preserves the approve-before-act model used by `/reply` and `/schedule`.
- Hard iteration cap + error-`tool_result` for unknown/raising tools so the loop can't run away or crash. Shared `MODEL` constant added to `app/ai/__init__.py`.
- Satisfies the program's "advanced LLM" bar via Function Calling **and** Agentic Flow, reusing Gmail + Calendar + DB.

## Test plan
- [x] All tests pass locally (217 passed, 92.17% coverage; `agent.py` 87%)
- [x] black + flake8 clean
- [x] Unit: tool-use loop (read-only exec + feedback, mutating queued, clean termination, iteration cap, unknown/raising tool), `execute_action`/`describe_action`, `/agent` + Approve/Cancel handlers
- [x] Self-skipping live-Claude integration test asserting a `tool_use` block