### PR TITLE
chore: centralize model id, logging, async offload, agent prompt caching

### DIFF
--- a/app/ai/agent.py
+++ b/app/ai/agent.py
@@ -234,7 +234,12 @@ def run_agent(instruction: str) -> tuple[str, list[dict]]:
         response = client.messages.create(
             model=MODEL,
             max_tokens=MAX_TOKENS,
-            system=SYSTEM_PROMPT,
+            # One breakpoint on system caches tools + system together (render order
+            # is tools -> system -> messages), so every round and back-to-back
+            # request re-reads the stable prefix instead of reprocessing it.
+            system=[
+                {"type": "text", "text": SYSTEM_PROMPT, "cache_control": {"type": "ephemeral"}}
+            ],
             tools=TOOLS,
             messages=messages,
         )

--- a/app/ai/analyzer.py
+++ b/app/ai/analyzer.py
@@ -1,7 +1,12 @@
 import json
+import logging
 import os
 
 from anthropic import Anthropic
+
+from app.ai import MODEL
+
+logger = logging.getLogger(__name__)
 
 _client = None
 
@@ -42,7 +47,7 @@ def analyze_email(email_data: dict) -> dict | None:
 
     try:
         message = _get_client().messages.create(
-            model="claude-sonnet-4-20250514",
+            model=MODEL,
             max_tokens=1000,
             messages=[{"role": "user", "content": prompt}],
         )
@@ -58,8 +63,8 @@ def analyze_email(email_data: dict) -> dict | None:
 
         return json.loads(response_text)
     except json.JSONDecodeError as e:
-        print(f"Failed to parse analysis JSON: {e}")
+        logger.warning("Failed to parse analysis JSON: %s", e)
         return None
-    except Exception as e:
-        print(f"Claude API error: {e}")
+    except Exception:
+        logger.exception("Claude API error during analysis")
         return None

--- a/app/ai/meeting_detector.py
+++ b/app/ai/meeting_detector.py
@@ -6,17 +6,19 @@ idempotent so the same email can be re-analyzed without duplicating rows.
 """
 
 import json
+import logging
 import os
 
 from anthropic import Anthropic
 
+from app.ai import MODEL
 from app.database import db
+
+logger = logging.getLogger(__name__)
 
 _client = None
 
 CONFIDENCE_THRESHOLD = 0.6
-
-MEETING_MODEL = "claude-sonnet-4-20250514"
 
 MEETING_PROMPT = """Extract meeting/event details from this email and respond with JSON.
 
@@ -62,7 +64,7 @@ def detect_meeting(email_data: dict) -> dict | None:
 
     try:
         message = _get_client().messages.create(
-            model=MEETING_MODEL,
+            model=MODEL,
             max_tokens=1000,
             messages=[{"role": "user", "content": prompt}],
         )
@@ -77,10 +79,10 @@ def detect_meeting(email_data: dict) -> dict | None:
 
         parsed = json.loads(response_text)
     except json.JSONDecodeError as e:
-        print(f"Failed to parse meeting JSON: {e}")
+        logger.warning("Failed to parse meeting JSON: %s", e)
         return None
-    except Exception as e:
-        print(f"Claude API error in detect_meeting: {e}")
+    except Exception:
+        logger.exception("Claude API error in detect_meeting")
         return None
 
     participants = parsed.get("participants") or []

--- a/app/ai/reply_generator.py
+++ b/app/ai/reply_generator.py
@@ -5,14 +5,17 @@ JSONDecodeError is intentionally caught separately from generic Exception
 so future schema changes are debuggable.
 """
 
+import logging
 import os
 
 from anthropic import Anthropic
 
+from app.ai import MODEL
 from app.ai.prompts import TONES, build_reply_prompt
 
-MODEL_ID = "claude-sonnet-4-20250514"
 MAX_TOKENS = 1024
+
+logger = logging.getLogger(__name__)
 
 _client: Anthropic | None = None
 
@@ -30,12 +33,12 @@ def _generate_one(email: dict, tone: str) -> str | None:
     prompt = build_reply_prompt(email, tone)
     try:
         message = _get_client().messages.create(
-            model=MODEL_ID,
+            model=MODEL,
             max_tokens=MAX_TOKENS,
             messages=[{"role": "user", "content": prompt}],
         )
-    except Exception as e:  # noqa: BLE001 — log + return None, caller decides UX
-        print(f"Claude reply generation failed for tone={tone}: {e}")
+    except Exception:  # noqa: BLE001 — log + return None, caller decides UX
+        logger.exception("Claude reply generation failed for tone=%s", tone)
         return None
 
     text = message.content[0].text.strip()

--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -1,5 +1,6 @@
 """Telegram bot command handlers + single-user auth guard."""
 
+import asyncio
 import logging
 import os
 from functools import wraps
@@ -165,7 +166,7 @@ async def analyze(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     blocks: list[str] = []
     for email in pending:
         await _typing(update)
-        analysis = analyze_email(email)
+        analysis = await asyncio.to_thread(analyze_email, email)
         if not analysis:
             blocks.append(
                 f"⚠️ *\\#{email.get('id', '?')}* "
@@ -173,7 +174,7 @@ async def analyze(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             )
             continue
         db.update_analysis(email["gmail_message_id"], analysis)
-        maybe_detect_meeting(email, analysis)
+        await asyncio.to_thread(maybe_detect_meeting, email, analysis)
         blocks.append(format_analysis_entry(email, analysis))
 
     if blocks:
@@ -239,7 +240,7 @@ async def _run_reply_flow(update: Update, email_id: int) -> None:
     await _typing(update)
     await chat.send_message("✍️ Drafting 3 replies… ~10s.")
     await _typing(update)
-    replies = generate_replies(email)
+    replies = await asyncio.to_thread(generate_replies, email)
     if not replies:
         await chat.send_message("Couldn't draft replies — try again in a moment.")
         return
@@ -399,7 +400,7 @@ async def cb_regenerate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         return
 
     await _typing(update)
-    new_text = regenerate_one(email, draft["tone"])
+    new_text = await asyncio.to_thread(regenerate_one, email, draft["tone"])
     if not new_text:
         await update.effective_chat.send_message(f"Regenerate failed for {draft['tone']}.")
         return
@@ -564,7 +565,7 @@ async def agent_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     await chat.send_message("🤖 Working on it…")
     await _typing(update)
     try:
-        text, pending = agent.run_agent(instruction)
+        text, pending = await asyncio.to_thread(agent.run_agent, instruction)
     except Exception as exc:  # noqa: BLE001 — surface a generic failure to the user
         logger.exception("Agent run failed")
         await chat.send_message(f"Agent failed: {exc}")


### PR DESCRIPTION
Closes #42

## Summary
- Centralized the Claude model id in `app/ai/__init__.py::MODEL` (analyzer / meeting_detector / reply_generator stop hardcoding it).
- Swapped `print()` for module loggers in the AI modules so errors reach journald/CloudWatch.
- Wrapped blocking Claude calls (`analyze_email`, `maybe_detect_meeting`, `generate_replies`, `regenerate_one`, `run_agent`) in `asyncio.to_thread` so they don't block the event loop.
- Added `cache_control` to the agent's system block — caches tools + system across tool-use rounds and back-to-back requests.

## Test plan
- [x] 217 passed, 92.22% coverage; black + flake8 clean
- [x] No behavior change exercised by tests (mocked clients); pure quality/perf polish