### PR TITLE
fix: root logger at INFO so app + scheduler logs reach journald (W6-C)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,6 @@ TELEGRAM_PUSH_THRESHOLD=4
 # Gmail OAuth health monitor (W6-C) — DMs you when the token expires/revokes
 TELEGRAM_OAUTH_CHECK_ENABLED=true
 TELEGRAM_OAUTH_CHECK_INTERVAL_HOURS=24
+
+# Root log level (W6-C) — INFO surfaces app + scheduler logs in journald/CloudWatch
+LOG_LEVEL=INFO

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,7 @@ Listed in `.env.example`. Don't commit real values.
 | `TELEGRAM_PUSH_THRESHOLD` | Notify only when `urgency_score >= N` (default `4`) |
 | `TELEGRAM_OAUTH_CHECK_ENABLED` | `true`/`false` — auto-start the Gmail OAuth health monitor on startup (default `true`) |
 | `TELEGRAM_OAUTH_CHECK_INTERVAL_HOURS` | OAuth check interval in hours, minimum 5 minutes (default `24`) |
+| `LOG_LEVEL` | Root logger level set at startup so app + scheduler logs reach journald (default `INFO`) |
 
 `token.pickle` (Gmail OAuth) is generated on first auth and refreshed automatically. If `invalid_grant` errors appear, the refresh token has been revoked (Google revokes tokens for "Testing" apps after ~7 days of inactivity) — delete `token.pickle` and re-run `python -c "from app.gmail.auth import get_credentials; get_credentials()"` to re-auth.
 

--- a/app/main.py
+++ b/app/main.py
@@ -23,6 +23,15 @@ app = FastAPI(title="AI Email Copilot")
 
 @app.on_event("startup")
 async def startup():
+    # Configure the root logger so app + APScheduler INFO logs reach stdout →
+    # journald → CloudWatch. uvicorn only wires its own `uvicorn.*` loggers, so
+    # without this `logger.info(...)` from our modules is invisible on the server.
+    # Done here (not at import) so it doesn't reconfigure logging during tests.
+    logging.basicConfig(
+        level=os.getenv("LOG_LEVEL", "INFO").upper(),
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
     db.init_db()
 
     webhook_url = os.getenv("TELEGRAM_WEBHOOK_URL")


### PR DESCRIPTION
Closes #46

## Summary
- Set the root logger at FastAPI startup (`logging.basicConfig(level=LOG_LEVEL, ...)`, default INFO) so app `logger.info(...)` and APScheduler logs reach stdout → journald → CloudWatch. uvicorn's loggers stop at `uvicorn` (propagate=False), so no duplicate lines.
- Done inside the startup handler (not at import) so it doesn't reconfigure logging during tests.
- New `LOG_LEVEL` env var (default INFO), documented in `.env.example` + `CLAUDE.md`.
- Closes the last W6-C observability gap before CloudWatch/alarms.

## Test plan
- [x] 230 passed, 92.36% coverage; black + flake8 clean (main.py is coverage-omitted)
- [ ] Post-deploy: `journalctl -u copilot` shows "OAuth monitor started" / "Push scheduler started"