### PR TITLE
fix: refuse to draft or send replies to no-reply senders

### DIFF
--- a/app/gmail/service.py
+++ b/app/gmail/service.py
@@ -58,6 +58,41 @@ def parse_email(msg_data):
     }
 
 
+NO_REPLY_PATTERNS: tuple[str, ...] = (
+    "noreply",
+    "no-reply",
+    "no_reply",
+    "donotreply",
+    "do-not-reply",
+    "do_not_reply",
+)
+
+
+def extract_email_address(sender: str | None) -> str | None:
+    """Pull the bare address out of a From header like 'Name <a@b.com>'."""
+    if not sender:
+        return None
+    start = sender.rfind("<")
+    end = sender.rfind(">")
+    if start != -1 and end != -1 and end > start:
+        addr = sender[start + 1 : end]
+    else:
+        addr = sender
+    return addr.strip() or None
+
+
+def is_no_reply_sender(sender: str | None) -> bool:
+    """True when the sender looks like a no-reply / automated mailbox.
+
+    A reply to these bounces, so the bot refuses rather than drafting + sending.
+    """
+    addr = extract_email_address(sender)
+    if not addr or "@" not in addr:
+        return False
+    local = addr.split("@", 1)[0].lower()
+    return any(pattern in local for pattern in NO_REPLY_PATTERNS)
+
+
 REPLY_HEADERS = ["From", "To", "Subject", "Message-ID", "References", "Reply-To"]
 
 

--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -16,6 +16,7 @@ from app.ai.reply_generator import generate_replies, regenerate_one
 from app.calendar import scheduler
 from app.database import db
 from app.gmail.service import get_recent_emails as gmail_fetch_recent
+from app.gmail.service import is_no_reply_sender
 from app.gmail.service import send_reply as gmail_send_reply
 from app.telegram import push as telegram_push
 from app.telegram.conversations import WAITING_FOR_TEXT, build_edit_handler
@@ -236,6 +237,12 @@ async def _run_reply_flow(update: Update, email_id: int) -> None:
     if not email.get("processed_at"):
         await chat.send_message(f"Email {email_id} hasn't been analyzed yet — run /analyze first.")
         return
+    if is_no_reply_sender(email.get("sender")):
+        await chat.send_message(
+            f"✋ {email.get('sender') or 'This sender'} is a no-reply address — "
+            "a reply would bounce, so I didn't draft one."
+        )
+        return
 
     await _typing(update)
     await chat.send_message("✍️ Drafting 3 replies… ~10s.")
@@ -315,6 +322,11 @@ async def _send_draft(
     email = db.get_email_by_row_id(draft["email_id"])
     if email is None:
         await update.effective_chat.send_message("Original email not found in DB.")
+        return
+    if is_no_reply_sender(email.get("sender")):
+        await update.effective_chat.send_message(
+            "✋ That email is from a no-reply address — a reply would bounce, so I didn't send it."
+        )
         return
 
     try:

--- a/tests/unit/test_gmail_no_reply.py
+++ b/tests/unit/test_gmail_no_reply.py
@@ -1,0 +1,52 @@
+"""Unit tests for no-reply sender detection (pure, no live API)."""
+
+import pytest
+
+from app.gmail.service import extract_email_address, is_no_reply_sender
+
+
+@pytest.mark.parametrize(
+    "sender,expected",
+    [
+        ("LinkedIn <messages-noreply@linkedin.com>", "messages-noreply@linkedin.com"),
+        ("bob@example.com", "bob@example.com"),
+        ("  Alice  <alice@example.com>  ", "alice@example.com"),
+        (None, None),
+        ("", None),
+        ("Just A Name", "Just A Name"),
+    ],
+)
+def test_extract_email_address(sender, expected):
+    assert extract_email_address(sender) == expected
+
+
+@pytest.mark.parametrize(
+    "sender",
+    [
+        "LinkedIn <messages-noreply@linkedin.com>",
+        "notifications-noreply@linkedin.com",
+        "no-reply@github.com",
+        "NoReply@Example.com",
+        "donotreply@bank.com",
+        "do-not-reply@service.io",
+        "jobs-noreply@indeed.com",
+    ],
+)
+def test_is_no_reply_sender_true_for_no_reply_addresses(sender):
+    assert is_no_reply_sender(sender) is True
+
+
+@pytest.mark.parametrize(
+    "sender",
+    [
+        "Alice <alice@example.com>",
+        "bob@example.com",
+        "recruiter@company.com",
+        None,
+        "",
+        "not-an-email",
+        "replyguy@example.com",  # 'reply' alone must not trigger
+    ],
+)
+def test_is_no_reply_sender_false_for_repliable_addresses(sender):
+    assert is_no_reply_sender(sender) is False

--- a/tests/unit/test_telegram_handlers.py
+++ b/tests/unit/test_telegram_handlers.py
@@ -279,6 +279,71 @@ async def test_reply_command_handles_empty_generation(
     assert "Couldn't draft replies" in _all_reply_texts(authorized_update)
 
 
+@pytest.mark.asyncio
+async def test_reply_command_skips_no_reply_sender(monkeypatch, authorized_update, reply_context):
+    """A no-reply sender must be refused before any draft is generated."""
+    row = _analyzed_email_row()
+    row["sender"] = "LinkedIn <messages-noreply@linkedin.com>"
+    monkeypatch.setattr(handlers.db, "get_email_by_row_id", lambda _: row)
+
+    gen_called = False
+
+    def fake_generate(_):
+        nonlocal gen_called
+        gen_called = True
+        return {"brief": "Yes"}
+
+    monkeypatch.setattr(handlers, "generate_replies", fake_generate)
+    reply_context.args = ["5"]
+    await handlers.reply_command(authorized_update, reply_context)
+
+    assert gen_called is False  # never reached draft generation
+    text = _all_reply_texts(authorized_update)
+    assert "no-reply address" in text
+    assert "Drafting" not in text
+
+
+@pytest.mark.asyncio
+async def test_cb_approve_blocks_no_reply_send(monkeypatch, reply_context):
+    """Defense-in-depth: approving a draft for a no-reply email must not send."""
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+    monkeypatch.setattr(
+        handlers.db,
+        "get_draft_by_id",
+        lambda _: {
+            "id": 7,
+            "email_id": 5,
+            "tone": "brief",
+            "draft_text": "Yes",
+            "status": "pending",
+        },
+    )
+    row = _analyzed_email_row()
+    row["sender"] = "notifications-noreply@linkedin.com"
+    monkeypatch.setattr(handlers.db, "get_email_by_row_id", lambda _: row)
+
+    send_called = False
+
+    def fake_send(*_):
+        nonlocal send_called
+        send_called = True
+        return "id"
+
+    monkeypatch.setattr(handlers, "gmail_send_reply", fake_send)
+    status_calls: list = []
+    monkeypatch.setattr(
+        handlers.db, "update_draft_status", lambda *a, **k: status_calls.append((a, k))
+    )
+
+    update = _make_callback_update("r:approve:7")
+    await handlers.cb_approve(update, reply_context)
+
+    assert send_called is False
+    assert status_calls == []  # draft NOT marked sent
+    assert "no-reply address" in update.effective_chat.send_message.await_args_list[-1].args[0]
+
+
 def _make_callback_update(data: str, chat_id: int = 42) -> MagicMock:
     update = MagicMock()
     update.effective_chat.id = chat_id


### PR DESCRIPTION
## Summary

`/reply` on an email from a no-reply / automated sender used to produce send-ready drafts (Approve would send a bouncing email), and the only safeguard was emergent — the model *sometimes* refused. This makes the refusal deterministic.

Closes #48

## Changes

- Add `is_no_reply_sender()` + `extract_email_address()` in `app/gmail/service.py` (pure, unit-tested).
- Gate `_run_reply_flow` in `app/telegram/handlers.py`: skip drafting for no-reply senders with a clear message.
- Defense-in-depth: `_send_draft` refuses to send to a no-reply sender, so the approve/edit/notification paths can't send a bouncing reply either.

## How to test

```bash
.venv/Scripts/black --check app/ tests/
.venv/Scripts/flake8 app/ tests/ --max-line-length=100
.venv/Scripts/pytest tests/ --cov=app
```

- [x] Unit tests added under `tests/unit/` (`test_gmail_no_reply.py` + 2 handler tests)
- [ ] Integration test (n/a — no new external boundary)
- [x] Manual verification: `/reply <id>` on a `*-noreply@` sender now replies "no-reply address … didn't draft one" instead of drafting.

## Checklist

- [x] Conventional Commits title
- [x] Body links the issue with `Closes #48`
- [x] Type hints + one-line docstrings on new functions
- [x] Coverage ≥ 80% (97% on `service.py`, suite 92.5%)
- [x] `black --check` and `flake8` pass locally

## Notes for the reviewer

Detection matches no-reply local-part patterns (`noreply`, `no-reply`, `donotreply`, etc.). It will not catch senders that are automated but lack a no-reply token in the address (e.g. `jobs-listings@`); broadening that is a possible follow-up.