### PR TITLE
fix: reply to unknown commands and plain text instead of silent drop

### DIFF
--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -7,7 +7,14 @@ from functools import wraps
 
 from telegram import BotCommand, InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.constants import ChatAction, ParseMode
-from telegram.ext import Application, CallbackQueryHandler, CommandHandler, ContextTypes
+from telegram.ext import (
+    Application,
+    CallbackQueryHandler,
+    CommandHandler,
+    ContextTypes,
+    MessageHandler,
+    filters,
+)
 
 from app.ai import agent
 from app.ai.analyzer import analyze_email
@@ -619,6 +626,21 @@ async def cb_agent_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     await update.effective_chat.send_message("✖ Cancelled — nothing was done.")
 
 
+@authorized_only
+async def unknown_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Catch-all for unrecognized /commands so the user isn't left guessing."""
+    await update.message.reply_text("Unknown command. Send /help to see what I can do.")
+
+
+@authorized_only
+async def fallback_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Catch-all for plain (non-command) text so the bot always responds."""
+    await update.message.reply_text(
+        "I only respond to commands. Send /help to see them, "
+        "or use /agent <text> to ask in natural language."
+    )
+
+
 def register(application: Application) -> None:
     """Register all command handlers on the given Application."""
     application.add_handler(CommandHandler("start", start))
@@ -644,3 +666,8 @@ def register(application: Application) -> None:
     application.add_handler(CallbackQueryHandler(cb_schedule_skip, pattern=r"^s:skip:\d+$"))
     application.add_handler(CallbackQueryHandler(cb_agent_approve, pattern=r"^a:approve$"))
     application.add_handler(CallbackQueryHandler(cb_agent_cancel, pattern=r"^a:cancel$"))
+
+    # Fallbacks LAST so they never shadow known commands or the edit conversation:
+    # an unrecognized /command, then any plain (non-command) text.
+    application.add_handler(MessageHandler(filters.COMMAND, unknown_command))
+    application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, fallback_text))

--- a/tests/unit/test_telegram_handlers.py
+++ b/tests/unit/test_telegram_handlers.py
@@ -1023,3 +1023,41 @@ async def test_cb_agent_cancel_discards(monkeypatch, reply_context):
     await handlers.cb_agent_cancel(update, reply_context)
     assert "agent_pending" not in reply_context.user_data
     assert "Cancelled" in update.effective_chat.send_message.await_args_list[-1].args[0]
+
+
+@pytest.mark.asyncio
+async def test_unknown_command_replies_hint(authorized_update):
+    await handlers.unknown_command(authorized_update, None)
+    text = _all_reply_texts(authorized_update)
+    assert "Unknown command" in text
+    assert "/help" in text
+
+
+@pytest.mark.asyncio
+async def test_fallback_text_replies_hint(authorized_update):
+    await handlers.fallback_text(authorized_update, None)
+    text = _all_reply_texts(authorized_update)
+    assert "/help" in text
+
+
+@pytest.mark.asyncio
+async def test_unknown_command_drops_unauthorized(monkeypatch):
+    """The @authorized_only guard must still silently drop foreign chats."""
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    update = MagicMock()
+    update.effective_chat.id = 99
+    update.message.reply_text = AsyncMock()
+    await handlers.unknown_command(update, None)
+    update.message.reply_text.assert_not_awaited()
+
+
+def test_register_adds_exactly_two_fallback_message_handlers():
+    """Fallbacks must be registered (and only the two), so plain text/unknown
+    commands get a reply without shadowing the edit ConversationHandler."""
+    from telegram.ext import MessageHandler
+
+    app = MagicMock()
+    handlers.register(app)
+    added = [c.args[0] for c in app.add_handler.call_args_list]
+    msg_handlers = [h for h in added if isinstance(h, MessageHandler)]
+    assert len(msg_handlers) == 2


### PR DESCRIPTION
## Summary

Unknown commands (`/foo`) and plain non-command text got no response at all — the bot looked broken. Add catch-all handlers so the user always gets a pointer to `/help`.

Closes #49

## Changes

- Add `@authorized_only` `unknown_command` and `fallback_text` handlers in `app/telegram/handlers.py`.
- Register them LAST in `register()` via `MessageHandler(filters.COMMAND, …)` and `MessageHandler(filters.TEXT & ~filters.COMMAND, …)` so they never shadow known commands or the edit `ConversationHandler`.
- Unauthorized chats are still silently dropped (guard unchanged).

## How to test

```bash
.venv/Scripts/black --check app/ tests/
.venv/Scripts/flake8 app/ tests/ --max-line-length=100
.venv/Scripts/pytest tests/ --cov=app
```

- [x] Unit tests added (unknown-command hint, plain-text fallback, unauthorized drop, register wiring)
- [ ] Integration test (n/a)
- [x] Manual verification: `/foo` → "Unknown command. Send /help…"; plain text → "I only respond to commands…".

## Checklist

- [x] Conventional Commits title
- [x] Body links the issue with `Closes #49`
- [x] Type hints + one-line docstrings on new handlers
- [x] Coverage ≥ 80% (94% on `handlers.py`, suite 94%)
- [x] `black --check` and `flake8` pass locally

## Notes for the reviewer

Plain text points to `/help` and `/agent` rather than auto-routing to the agent — the conservative choice so casual messages don't trigger agent actions. Easy to change if you'd prefer auto-routing.