### PR TITLE
fix: clarify /unread list numbers are not /reply ids

### DIFF
--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -146,6 +146,11 @@ async def unread(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         await update.message.reply_text(f"Gmail error: {exc}")
         return
     blocks = [format_unread_entry(email, i + 1) for i, email in enumerate(emails)]
+    if blocks:
+        blocks.append(
+            "_These numbers are just list positions, not reply ids\\. "
+            "To reply, run /analyze then use the \\#id shown by /inbox\\._"
+        )
     await _send_chunks(update, blocks, "No unread emails.")
 
 

--- a/tests/unit/test_telegram_handlers.py
+++ b/tests/unit/test_telegram_handlers.py
@@ -60,6 +60,20 @@ async def test_unread_replies_empty_message_when_no_unread(monkeypatch, authoriz
 
 
 @pytest.mark.asyncio
+async def test_unread_appends_clarifying_id_footer(monkeypatch, authorized_update):
+    """The list numbers aren't /reply ids — a footer must say so to avoid the footgun."""
+    monkeypatch.setattr(
+        handlers,
+        "gmail_fetch_recent",
+        lambda max_results, unread_only: [{"sender": "a@b.com", "subject": "Hi", "snippet": "x"}],
+    )
+    await handlers.unread(authorized_update, None)
+    text = _all_reply_texts(authorized_update)
+    assert "not reply ids" in text
+    assert "/inbox" in text
+
+
+@pytest.mark.asyncio
 async def test_unread_reports_gmail_error(monkeypatch, authorized_update):
     def raise_runtime(**_):
         raise RuntimeError("boom")


### PR DESCRIPTION
## Summary

`/unread` numbers entries 1..N, but those are list positions of freshly-fetched Gmail emails (no DB row id), so they can't be used with `/reply` — which only works on analyzed emails shown by `/inbox`. Add a footer to remove the footgun.

Closes #50

## Changes

- `unread` handler appends a footer: the numbers are list positions, not reply ids; run /analyze then use the #id from /inbox.

## How to test

```bash
.venv/Scripts/black --check app/ tests/
.venv/Scripts/flake8 app/ tests/ --max-line-length=100
.venv/Scripts/pytest tests/ --cov=app
```

- [x] Unit test added (`test_unread_appends_clarifying_id_footer`)
- [x] Manual verification: `/unread` now ends with the clarifying footer.

## Checklist

- [x] Conventional Commits title
- [x] Body links the issue with `Closes #50`
- [x] `black --check` and `flake8` pass locally
- [x] Coverage ≥ 80% (suite 92.4%)

## Notes for the reviewer

Chose a clarifying footer rather than a fake id because `/unread` doesn't persist emails — there's no DB id to show. If you'd rather `/unread` store-on-fetch and show real ids, that's a larger change worth its own issue.