### PR TITLE
fix: acknowledge ignored extra arguments on /reply and /analyze

### DIFF
--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -153,6 +153,11 @@ async def unread(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 async def analyze(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Run Claude on every unprocessed email in the DB and reply with results."""
     await _typing(update)
+    extra = getattr(context, "args", None) or []
+    if extra:
+        await update.message.reply_text(
+            f"(/analyze takes no arguments — ignoring: {' '.join(extra)})"
+        )
     pending = db.get_unprocessed_emails()
     if not pending:
         await update.message.reply_text("No emails to analyze.")
@@ -274,6 +279,10 @@ async def reply_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     if not args or not args[0].isdigit():
         await update.effective_chat.send_message("Usage: /reply <email_id>")
         return
+    if len(args) > 1:
+        await update.effective_chat.send_message(
+            f"Ignoring extra argument(s): {' '.join(args[1:])}"
+        )
     await _run_reply_flow(update, int(args[0]))
 
 

--- a/tests/unit/test_telegram_handlers.py
+++ b/tests/unit/test_telegram_handlers.py
@@ -212,6 +212,39 @@ async def test_reply_command_rejects_missing_arg(monkeypatch, authorized_update,
 
 
 @pytest.mark.asyncio
+async def test_reply_command_notes_ignored_extra_args(
+    monkeypatch, authorized_update, reply_context
+):
+    """`/reply 5 banana` must run for id 5 but tell the user 'banana' was ignored."""
+    flow_calls: list = []
+
+    async def fake_flow(update, email_id):
+        flow_calls.append(email_id)
+
+    monkeypatch.setattr(handlers, "_run_reply_flow", fake_flow)
+    reply_context.args = ["5", "banana"]
+    await handlers.reply_command(authorized_update, reply_context)
+
+    assert flow_calls == [5]  # still ran for the valid id
+    text = _all_reply_texts(authorized_update)
+    assert "Ignoring extra argument" in text
+    assert "banana" in text
+
+
+@pytest.mark.asyncio
+async def test_analyze_notes_ignored_args(monkeypatch, authorized_update, reply_context):
+    """`/analyze 999` must say the arg is ignored and still run normally."""
+    monkeypatch.setattr(handlers.db, "get_unprocessed_emails", list)
+    reply_context.args = ["999"]
+    await handlers.analyze(authorized_update, reply_context)
+
+    text = _all_reply_texts(authorized_update)
+    assert "ignoring" in text.lower()
+    assert "999" in text
+    assert "No emails to analyze." in text
+
+
+@pytest.mark.asyncio
 async def test_reply_command_rejects_unknown_email(monkeypatch, authorized_update, reply_context):
     monkeypatch.setattr(handlers.db, "get_email_by_row_id", lambda _: None)
     reply_context.args = ["999"]


### PR DESCRIPTION
## Summary

Commands silently dropped extra arguments (`/reply 1 banana` ignored "banana"; `/analyze 999` ignored "999") with no feedback. Now they acknowledge the ignored tokens.

Closes #51

## Changes

- `reply_command`: if more than the id is passed, send "Ignoring extra argument(s): …" then proceed with the valid id.
- `analyze`: if any args are passed, send "(/analyze takes no arguments — ignoring: …)" then run normally.

## How to test

```bash
.venv/Scripts/black --check app/ tests/
.venv/Scripts/flake8 app/ tests/ --max-line-length=100
.venv/Scripts/pytest tests/ --cov=app
```

- [x] Unit tests added (`test_reply_command_notes_ignored_extra_args`, `test_analyze_notes_ignored_args`)
- [x] Manual verification: `/reply 5 banana` → notes "banana" ignored, still drafts for 5; `/analyze 999` → notes ignored, runs.

## Checklist

- [x] Conventional Commits title
- [x] Body links the issue with `Closes #51`
- [x] `black --check` and `flake8` pass locally
- [x] Coverage ≥ 80% (suite 92.4%)