### PR TITLE
fix: give /reply a realistic drafting ETA

### DIFF
--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -238,7 +238,7 @@ async def _run_reply_flow(update: Update, email_id: int) -> None:
         return
 
     await _typing(update)
-    await chat.send_message("✍️ Drafting 3 replies… ~10s.")
+    await chat.send_message("✍️ Drafting 3 replies… this can take up to a minute.")
     await _typing(update)
     replies = await asyncio.to_thread(generate_replies, email)
     if not replies:

--- a/tests/unit/test_telegram_handlers.py
+++ b/tests/unit/test_telegram_handlers.py
@@ -279,6 +279,24 @@ async def test_reply_command_handles_empty_generation(
     assert "Couldn't draft replies" in _all_reply_texts(authorized_update)
 
 
+@pytest.mark.asyncio
+async def test_reply_drafting_message_has_realistic_eta(monkeypatch, authorized_update):
+    """The progress message must not under-promise the ~1 min generation time."""
+    monkeypatch.setattr(handlers.db, "get_email_by_row_id", lambda _: _analyzed_email_row())
+    monkeypatch.setattr(handlers, "generate_replies", lambda _: {"brief": "Yes"})
+    monkeypatch.setattr(handlers.db, "insert_draft_reply", lambda *_: 1)
+    monkeypatch.setattr(
+        handlers.db,
+        "get_draft_by_id",
+        lambda did: {"id": did, "tone": "brief", "draft_text": "Yes"},
+    )
+    await handlers._run_reply_flow(authorized_update, 5)
+    text = _all_reply_texts(authorized_update)
+    assert "Drafting" in text
+    assert "~10s" not in text
+    assert "minute" in text
+
+
 def _make_callback_update(data: str, chat_id: int = 42) -> MagicMock:
     update = MagicMock()
     update.effective_chat.id = chat_id


### PR DESCRIPTION
## Summary

`/reply` said "Drafting 3 replies… ~10s." but generating 3 sequential Claude drafts takes ~1 minute. Reword so the wait doesn't look like a hang.

Closes #52

## Changes

- `_run_reply_flow` progress message: "~10s." → "this can take up to a minute."

## How to test

```bash
.venv/Scripts/black --check app/ tests/
.venv/Scripts/flake8 app/ tests/ --max-line-length=100
.venv/Scripts/pytest tests/ --cov=app
```

- [x] Unit test added (`test_reply_drafting_message_has_realistic_eta`)
- [x] Manual verification: `/reply <id>` shows the new wording.

## Checklist

- [x] Conventional Commits title
- [x] Body links the issue with `Closes #52`
- [x] `black --check` and `flake8` pass locally
- [x] Coverage ≥ 80% (suite 92.4%)

## Notes for the reviewer

Kept this to a copy change. Actually speeding it up (parallelizing the 3 tone calls with `asyncio.gather`/threads) would be a nice follow-up but is a larger change to `generate_replies` — happy to open a separate issue if you want it.