### PR TITLE
fix: make /inbox ordering deterministic with id tiebreaker

### DIFF
--- a/app/database/db.py
+++ b/app/database/db.py
@@ -202,7 +202,7 @@ def get_recent_emails(limit: int = 50) -> list[dict]:
     conn = get_connection()
     try:
         rows = conn.execute(
-            "SELECT * FROM emails ORDER BY created_at DESC LIMIT ?", (limit,)
+            "SELECT * FROM emails ORDER BY created_at DESC, id DESC LIMIT ?", (limit,)
         ).fetchall()
         return [dict(row) for row in rows]
     finally:

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -42,6 +42,25 @@ def test_insert_email_returns_row_id():
     assert row_id is not None and row_id > 0
 
 
+def test_get_recent_emails_orders_newest_first_deterministically():
+    """Equal created_at (batch inserts) must break ties on id DESC, not arbitrarily."""
+    for i in range(1, 4):
+        db.insert_email(
+            {
+                "id": f"m{i}",
+                "thread_id": "t",
+                "sender": "a@b.com",
+                "subject": f"s{i}",
+                "body": "b",
+                "snippet": "",
+                "date": "2026-04-15",
+            }
+        )
+    rows = db.get_recent_emails(limit=10)
+    ids = [r["id"] for r in rows]
+    assert ids == [3, 2, 1]
+
+
 def test_insert_email_is_idempotent():
     email = {
         "id": "msg_dup",


### PR DESCRIPTION
## Summary

`/inbox` ordered by `created_at DESC` only, so emails inserted in the same batch (equal `created_at` second) came back in arbitrary order — producing the non-intuitive sequence seen in QA. Add `id DESC` as a stable tiebreaker.

Closes #53

## Changes

- `get_recent_emails`: `ORDER BY created_at DESC` → `ORDER BY created_at DESC, id DESC`.

## How to test

```bash
.venv/Scripts/black --check app/ tests/
.venv/Scripts/flake8 app/ tests/ --max-line-length=100
.venv/Scripts/pytest tests/ --cov=app
```

- [x] Unit test added (`test_get_recent_emails_orders_newest_first_deterministically`)

## Checklist

- [x] Conventional Commits title
- [x] Body links the issue with `Closes #53`
- [x] `black --check` and `flake8` pass locally
- [x] Coverage ≥ 80% (suite 92.8%)

## Notes for the reviewer

**Deviation from the issue:** the issue suggested ordering by `received_date`, but that column stores the raw RFC 2822 `Date` header (e.g. "Sat, 24 May 2026…"), which sorts lexicographically by weekday — not chronologically. `created_at` is a sortable ISO timestamp (`datetime('now')`), so the real bug was just the missing tiebreaker. If you want true received-time ordering, that needs a separate change to store a parsed/ISO received timestamp on ingest — happy to file that as a follow-up.