### PR TITLE
fix: /agent returns interim preamble instead of final answer for complex requests

### DIFF
--- a/app/ai/agent.py
+++ b/app/ai/agent.py
@@ -21,8 +21,13 @@ from app.gmail.service import send_reply as gmail_send_reply
 
 _client: Anthropic | None = None
 
-MAX_TOKENS = 1024
-MAX_ITERATIONS = 5
+MAX_TOKENS = 2048
+MAX_ITERATIONS = 8
+
+# Shown when the loop hits MAX_ITERATIONS and even a forced final turn yields no text.
+CAP_FALLBACK = (
+    "I couldn't finish that in the steps available — try a narrower or more specific request."
+)
 
 SYSTEM_PROMPT = (
     "You are an email assistant agent operating over the user's Gmail and Google "
@@ -229,6 +234,7 @@ def run_agent(instruction: str) -> tuple[str, list[dict]]:
     messages: list[dict] = [{"role": "user", "content": instruction}]
     pending: list[dict] = []
     final_text = ""
+    finished = False
 
     for _ in range(MAX_ITERATIONS):
         response = client.messages.create(
@@ -248,6 +254,7 @@ def run_agent(instruction: str) -> tuple[str, list[dict]]:
             final_text = text
 
         if getattr(response, "stop_reason", None) != "tool_use":
+            finished = True
             break
 
         messages.append({"role": "assistant", "content": response.content})
@@ -262,7 +269,26 @@ def run_agent(instruction: str) -> tuple[str, list[dict]]:
         ]
         messages.append({"role": "user", "content": tool_results})
 
+    if not finished:
+        # The cap was hit mid-tool-loop, so final_text is at best interim narration
+        # ("let me analyze…"). Force one tool-free turn to synthesize a real answer from
+        # what was already gathered, rather than returning that dangling preamble.
+        final_text = _force_final_answer(client, messages) or final_text or CAP_FALLBACK
+
     return final_text.strip(), pending
+
+
+def _force_final_answer(client: Anthropic, messages: list[dict]) -> str:
+    """One tool-disabled turn so the model answers from gathered context after the cap."""
+    response = client.messages.create(
+        model=MODEL,
+        max_tokens=MAX_TOKENS,
+        system=[{"type": "text", "text": SYSTEM_PROMPT, "cache_control": {"type": "ephemeral"}}],
+        tools=TOOLS,
+        tool_choice={"type": "none"},
+        messages=messages,
+    )
+    return _collect_text(response.content)
 
 
 # --- Mutating action execution (run only after user approval) ------------------

--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -134,6 +134,16 @@ async def _typing(update: Update) -> None:
         logger.debug("send_chat_action failed; continuing without typing indicator")
 
 
+async def _safe_delete(message) -> None:
+    """Best-effort removal of a transient status message; never fail the handler over it."""
+    if message is None:
+        return
+    try:
+        await message.delete()
+    except Exception:  # noqa: BLE001 — cleanup is cosmetic
+        logger.debug("status message delete failed; leaving it in place")
+
+
 async def _send_chunks(update: Update, blocks: list[str], empty_message: str) -> None:
     """Render blocks via chunk_messages and send each as MarkdownV2."""
     if not blocks:
@@ -595,14 +605,17 @@ async def agent_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         return
 
     await _typing(update)
-    await chat.send_message("🤖 Working on it…")
+    status = await chat.send_message("🤖 Working on it…")
     await _typing(update)
     try:
         text, pending = await asyncio.to_thread(agent.run_agent, instruction)
     except Exception as exc:  # noqa: BLE001 — surface a generic failure to the user
         logger.exception("Agent run failed")
+        await _safe_delete(status)
         await chat.send_message(f"Agent failed: {exc}")
         return
+
+    await _safe_delete(status)
 
     if not pending:
         await chat.send_message(text or "Done — nothing to do.")

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -107,8 +107,36 @@ def test_iteration_cap_stops_runaway_loop(monkeypatch):
 
     text, pending = agent.run_agent("loop forever")
 
-    assert len(client.calls) == agent.MAX_ITERATIONS
+    # MAX_ITERATIONS tool rounds + one forced final-answer turn.
+    assert len(client.calls) == agent.MAX_ITERATIONS + 1
     assert pending == []
+    # A pathological loop that yields no text still returns a usable fallback,
+    # never an empty/dangling response.
+    assert text == agent.CAP_FALLBACK
+
+
+def test_iteration_cap_forces_final_answer(monkeypatch):
+    """Hitting the cap mid-loop must synthesize a real answer, not return interim text."""
+    monkeypatch.setattr(agent.db, "get_recent_emails", lambda limit: [])
+    # Every in-loop round emits interim narration alongside a tool call (never a clean stop).
+    responses = [
+        _response(
+            "tool_use",
+            [_text("Now let me analyze each email…"), _tool(f"t{i}", "list_recent_emails", {})],
+        )
+        for i in range(agent.MAX_ITERATIONS)
+    ]
+    # The forced, tool-free turn returns the actual synthesized answer.
+    responses.append(_response("end_turn", [_text("Here is the full breakdown.")]))
+    client = _install(monkeypatch, responses)
+
+    text, pending = agent.run_agent("be very thorough about every unread email")
+
+    assert text == "Here is the full breakdown."  # not the interim "Now let me analyze…"
+    assert pending == []
+    assert len(client.calls) == agent.MAX_ITERATIONS + 1
+    # The final turn disables further tool use so the model must produce text.
+    assert client.calls[-1].get("tool_choice") == {"type": "none"}
 
 
 def test_unknown_tool_returns_error_result(monkeypatch):

--- a/tests/unit/test_telegram_handlers.py
+++ b/tests/unit/test_telegram_handlers.py
@@ -1076,6 +1076,20 @@ async def test_agent_command_text_only_no_pending(monkeypatch, authorized_update
 
 
 @pytest.mark.asyncio
+async def test_agent_command_deletes_status_message(monkeypatch, authorized_update, reply_context):
+    status = MagicMock()
+    status.delete = AsyncMock()
+    authorized_update.effective_chat.send_message = AsyncMock(return_value=status)
+    monkeypatch.setattr(handlers.agent, "run_agent", lambda instr: ("Summary.", []))
+    reply_context.args = ["summarize"]
+
+    await handlers.agent_command(authorized_update, reply_context)
+
+    # The transient "🤖 Working on it…" status is removed, not left orphaned.
+    status.delete.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_agent_command_with_pending_shows_keyboard_and_stores(
     monkeypatch, authorized_update, reply_context
 ):


### PR DESCRIPTION
Closes #61

## Summary
- Force one tool-disabled (`tool_choice: none`) synthesis turn when `run_agent`'s loop hits `MAX_ITERATIONS` mid-tool-use, so the user gets a real answer instead of the interim "Now let me analyze…" preamble that was being returned.
- Add an explicit `CAP_FALLBACK` message for the pathological case where even the forced turn yields no text — no more empty/dangling responses.
- Bump `MAX_TOKENS` (1024→2048) and `MAX_ITERATIONS` (5→8) so moderately complex multi-email requests can finish naturally inside the loop.
- Delete the "🤖 Working on it…" status message once the result is ready (via a small `_safe_delete` helper) — no longer left orphaned in chat.

## Root cause
`run_agent` overwrote `final_text` each round and only returned cleanly via `break` on a non-`tool_use` stop. When the loop exhausted `MAX_ITERATIONS=5` mid-tool-use (common for "be thorough" requests over ~20 emails), it silently returned the last interim text — typically the preamble emitted alongside the first tool call. The forced final turn fixes this by giving the model one tool-free chance to synthesize from the context it already gathered.

## Test plan
- [x] `pytest tests/unit/test_agent.py tests/unit/test_telegram_handlers.py` — 75 passed
- [x] Full suite + coverage: `pytest tests/ --cov=app` — 263 passed, 94.40% coverage
- [x] `black` clean, `flake8 --max-line-length=100` clean
- [x] New `test_iteration_cap_forces_final_answer` — verifies interim text is replaced by the synthesized answer and the final call sets `tool_choice: {"type": "none"}`
- [x] Updated `test_iteration_cap_stops_runaway_loop` — verifies pathological loops return `CAP_FALLBACK`, never an empty string
- [x] New `test_agent_command_deletes_status_message` — verifies the "Working on it…" message is deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)