### PR TITLE
ci: log stdout when deploy SSM command fails

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,17 @@ jobs:
                 exit 0
                 ;;
               Failed|Cancelled|TimedOut)
-                echo "Deploy command ended in ${STATUS}. stderr from instance:"
+                echo "Deploy command ended in ${STATUS}."
+                # Some failures (e.g. a bash chain dying on `cd nonexistent`) leave
+                # stderr empty but write the trace to stdout, so dump both — without
+                # stdout we got a blank stderr and no signal at all.
+                echo "--- stdout from instance ---"
+                aws ssm get-command-invocation \
+                  --command-id "${COMMAND_ID}" \
+                  --instance-id "${INSTANCE_ID}" \
+                  --query StandardOutputContent \
+                  --output text
+                echo "--- stderr from instance ---"
                 aws ssm get-command-invocation \
                   --command-id "${COMMAND_ID}" \
                   --instance-id "${INSTANCE_ID}" \


### PR DESCRIPTION
## Summary
- The current `Wait for SSM command` step only dumps `StandardErrorContent` on failure. Both recent deploy failures on `main` (bdbfff9, 1eb3e7a) returned `Status: Failed` in ~1s with **empty stderr**, leaving us no idea which command on the instance broke.
- Patch dumps `StandardOutputContent` too, since a chained `cd … && git … && …` that dies on the first `cd` (or any step that writes only to stdout) puts the trace there.

## Context
The docs-only commit `1eb3e7a` (touched only `docs/PROGRESS.md`) failed identically to `bdbfff9`, so the root cause is on the EC2 side, not in the codebase. This patch is purely diagnostic — the next failed deploy will tell us *which* command (`cd /home/copilot/email-assistant`? `git checkout`? `pip install`? `systemctl restart`?) is failing.

## Test plan
- [x] YAML still parses (Actions UI accepts the workflow)
- [ ] After merge to `main`, the deploy will likely still fail — but the run log will now show the instance's stdout, surfacing the real error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)