### PR TITLE
ci: log instance stdout when deploy SSM command fails

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,17 @@ jobs:
                 exit 0
                 ;;
               Failed|Cancelled|TimedOut)
-                echo "Deploy command ended in ${STATUS}. stderr from instance:"
+                echo "Deploy command ended in ${STATUS}."
+                # Some failures (e.g. a bash chain dying on `cd nonexistent`) leave
+                # stderr empty but write the trace to stdout, so dump both — without
+                # stdout we got a blank stderr and no signal at all.
+                echo "--- stdout from instance ---"
+                aws ssm get-command-invocation \
+                  --command-id "${COMMAND_ID}" \
+                  --instance-id "${INSTANCE_ID}" \
+                  --query StandardOutputContent \
+                  --output text
+                echo "--- stderr from instance ---"
                 aws ssm get-command-invocation \
                   --command-id "${COMMAND_ID}" \
                   --instance-id "${INSTANCE_ID}" \


### PR DESCRIPTION
## Summary
- When the deploy SSM command ends in `Failed`/`Cancelled`/`TimedOut`, also dump `StandardOutputContent` from the instance, not just stderr.
- Motivation: some bash failures (e.g. the chain dying on `cd nonexistent`) write the trace to stdout and leave stderr empty, so we were getting a blank `stderr from instance:` block with zero signal.

## Test plan
- [ ] Trigger a deploy failure (or wait for the next transient SSM `Failed`) and confirm the workflow log now shows a populated `--- stdout from instance ---` block.
- [ ] Confirm a successful deploy is unaffected (the new branch only runs in the `Failed|Cancelled|TimedOut` arm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)