### PR TITLE
ci(security): add Bandit, Dependabot, and Trivy scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-deps:
+        patterns: ["*"]
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,44 @@
+name: Security
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  bandit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install Bandit
+        run: |
+          python -m pip install --upgrade pip
+          pip install bandit
+
+      # -ll = report medium+ severity only, keeping low-confidence noise out of the gate
+      - name: Bandit scan
+        run: bandit -r app/ -ll
+
+  trivy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # exit-code: 0 keeps this report-only for the initial rollout. Flip to 1
+      # (gate the build) once the first run's HIGH/CRITICAL backlog is triaged — see #65.
+      - name: Trivy filesystem scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: "fs"
+          scan-ref: "."
+          severity: "HIGH,CRITICAL"
+          scanners: "vuln,secret,misconfig"
+          exit-code: "0"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,7 +35,7 @@ jobs:
       # exit-code: 0 keeps this report-only for the initial rollout. Flip to 1
       # (gate the build) once the first run's HIGH/CRITICAL backlog is triaged — see #65.
       - name: Trivy filesystem scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           scan-type: "fs"
           scan-ref: "."

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,7 +35,7 @@ jobs:
       # exit-code: 0 keeps this report-only for the initial rollout. Flip to 1
       # (gate the build) once the first run's HIGH/CRITICAL backlog is triaged — see #65.
       - name: Trivy filesystem scan
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: "fs"
           scan-ref: "."

--- a/app/gmail/auth.py
+++ b/app/gmail/auth.py
@@ -22,7 +22,8 @@ def get_credentials():
 
     if os.path.exists("token.pickle"):
         with open("token.pickle", "rb") as token:
-            creds = pickle.load(token)
+            # token.pickle is written by this app on the local host; not untrusted input.
+            creds = pickle.load(token)  # nosec B301
 
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
@@ -54,7 +55,7 @@ def gmail_token_status() -> tuple[bool, str]:
         return False, "no token.pickle"
     try:
         with open("token.pickle", "rb") as token:
-            creds = pickle.load(token)
+            creds = pickle.load(token)  # nosec B301
     except Exception as exc:  # noqa: BLE001 — corrupt/unreadable token file
         return False, f"unreadable token.pickle: {exc}"
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest-asyncio
 black
 flake8
 mypy
+bandit


### PR DESCRIPTION
Closes #65

## Summary
- **Dependabot** (`.github/dependabot.yml`): weekly `pip` + `github-actions` update PRs, grouped, with CVE alerts.
- **Bandit** (`.github/workflows/security.yml`): Python SAST over `app/` at medium+ severity (`-ll`) — required gate.
- **Trivy** (same workflow): filesystem `vuln,secret,misconfig` scan for HIGH/CRITICAL, report-only (`exit-code: 0`) for the initial rollout; flip-to-gate tracked in the workflow comment + #65.
- Two intentional `B301` pickle loads in `app/gmail/auth.py` (app-written, local `token.pickle`) suppressed with documented `# nosec B301`.

## Test plan
- [x] Bandit clean at medium+ locally (`bandit -r app/ -ll`)
- [x] black --check + flake8 clean
- [x] pytest: 263 passed, 94.4% coverage
- [ ] Lint / Tests / Security workflows green on this PR