### PR TITLE
feat(calendar): attach email summary + thread link to booked events

### DIFF
--- a/app/calendar/scheduler.py
+++ b/app/calendar/scheduler.py
@@ -12,6 +12,8 @@ from app.calendar import service
 
 DEFAULT_DURATION_MINUTES = 30
 
+_THREAD_URL = "https://mail.google.com/mail/u/0/#all/{thread_id}"
+
 
 def event_window(event_row: dict) -> tuple[str, str] | None:
     """Compute (start, end) as RFC3339 UTC for a detected event row.
@@ -42,11 +44,34 @@ def _to_rfc3339(value: datetime) -> str:
     return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def build_event_body(event_row: dict) -> dict:
+def build_description(email: dict | None) -> str | None:
+    """Build the event description from the source email: AI summary + thread link.
+
+    Returns None when neither a summary nor a thread link is available, so the
+    caller can omit the `description` key entirely rather than send an empty one.
+    """
+    if not email:
+        return None
+
+    parts: list[str] = []
+    summary = (email.get("ai_summary") or "").strip()
+    if summary:
+        parts.append(summary)
+
+    thread_id = email.get("thread_id")
+    if thread_id:
+        parts.append(f"📧 Source thread: {_THREAD_URL.format(thread_id=thread_id)}")
+
+    return "\n\n".join(parts) or None
+
+
+def build_event_body(event_row: dict, email: dict | None = None) -> dict:
     """Build the Google Calendar event resource from a detected event row.
 
-    Omits `location`/`attendees` rather than sending nulls so the API receives a
-    clean body. Raises ValueError if the row has no schedulable date+time.
+    Omits `location`/`attendees`/`description` rather than sending nulls so the API
+    receives a clean body. When `email` is given, attaches its summary + a Gmail
+    deep link as the event description. Raises ValueError if the row has no
+    schedulable date+time.
     """
     window = event_window(event_row)
     if window is None:
@@ -63,7 +88,11 @@ def build_event_body(event_row: dict) -> dict:
 
     attendees = _parse_participants(event_row.get("participants"))
     if attendees:
-        body["attendees"] = [{"email": email} for email in attendees]
+        body["attendees"] = [{"email": email_addr} for email_addr in attendees]
+
+    description = build_description(email)
+    if description:
+        body["description"] = description
 
     return body
 
@@ -84,8 +113,12 @@ def has_conflict(event_row: dict) -> bool:
     return bool(service.check_busy(start, end))
 
 
-def create_event(event_row: dict) -> str:
-    """Insert the event on the primary calendar; return the Google event id."""
-    body = build_event_body(event_row)
+def create_event(event_row: dict, email: dict | None = None) -> str:
+    """Insert the event on the primary calendar; return the Google event id.
+
+    `email` (the source email row) is threaded through so the booked event keeps
+    a summary + link back to the originating conversation.
+    """
+    body = build_event_body(event_row, email)
     created = service.insert_event(body)
     return created["id"]

--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -561,8 +561,9 @@ async def cb_schedule_create(update: Update, context: ContextTypes.DEFAULT_TYPE)
         )
         return
 
+    source_email = db.get_email_by_row_id(event["email_id"])
     try:
-        google_event_id = scheduler.create_event(event)
+        google_event_id = scheduler.create_event(event, source_email)
     except Exception as exc:  # noqa: BLE001 — surface a generic failure to the user
         logger.exception("Calendar insert failed for event=%s", event_id)
         db.update_calendar_event_status(event_id, "failed")

--- a/tests/unit/test_calendar_scheduler.py
+++ b/tests/unit/test_calendar_scheduler.py
@@ -63,6 +63,38 @@ def test_build_event_body_raises_without_window():
         scheduler.build_event_body(_row(event_time=None))
 
 
+def test_build_event_body_attaches_summary_and_thread_link():
+    email = {"ai_summary": "Alice wants to sync on Q3.", "thread_id": "abc123"}
+    body = scheduler.build_event_body(_row(), email)
+    assert "Alice wants to sync on Q3." in body["description"]
+    assert "https://mail.google.com/mail/u/0/#all/abc123" in body["description"]
+
+
+def test_build_event_body_description_summary_only_when_no_thread():
+    email = {"ai_summary": "Quick chat.", "thread_id": None}
+    body = scheduler.build_event_body(_row(), email)
+    assert body["description"] == "Quick chat."
+    assert "mail.google.com" not in body["description"]
+
+
+def test_build_event_body_omits_description_without_email():
+    assert "description" not in scheduler.build_event_body(_row())
+
+
+def test_build_event_body_omits_description_when_email_empty():
+    email = {"ai_summary": None, "thread_id": None}
+    assert "description" not in scheduler.build_event_body(_row(), email)
+
+
+def test_build_description_link_only_when_no_summary():
+    desc = scheduler.build_description({"ai_summary": "", "thread_id": "t9"})
+    assert desc == "📧 Source thread: https://mail.google.com/mail/u/0/#all/t9"
+
+
+def test_build_description_none_for_none_email():
+    assert scheduler.build_description(None) is None
+
+
 def test_has_conflict_true_when_busy(monkeypatch):
     monkeypatch.setattr(
         scheduler.service,

--- a/tests/unit/test_telegram_handlers.py
+++ b/tests/unit/test_telegram_handlers.py
@@ -902,6 +902,7 @@ def _detected_event(**overrides) -> dict:
     """A detected calendar_events row with a concrete date+time."""
     base = {
         "id": 3,
+        "email_id": 5,
         "title": "Sync with Alice",
         "event_date": "2026-05-19",
         "event_time": "15:00:00",
@@ -947,7 +948,14 @@ async def test_cb_schedule_create_free_window_creates(monkeypatch, reply_context
     monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
     monkeypatch.setattr(handlers.db, "get_calendar_event_by_id", lambda _: _detected_event())
     monkeypatch.setattr(handlers.scheduler, "has_conflict", lambda _: False)
-    monkeypatch.setattr(handlers.scheduler, "create_event", lambda _: "goog_evt_99")
+    source_email = {"id": 5, "ai_summary": "Q3 sync", "thread_id": "t1"}
+    monkeypatch.setattr(handlers.db, "get_email_by_row_id", lambda _: source_email)
+    create_args: dict = {}
+    monkeypatch.setattr(
+        handlers.scheduler,
+        "create_event",
+        lambda event, email=None: create_args.update(event=event, email=email) or "goog_evt_99",
+    )
     status_calls: list[tuple] = []
     monkeypatch.setattr(
         handlers.db,
@@ -960,6 +968,7 @@ async def test_cb_schedule_create_free_window_creates(monkeypatch, reply_context
 
     assert status_calls == [(3, "created", {"google_event_id": "goog_evt_99"})]
     assert "Event created" in update.effective_chat.send_message.await_args_list[-1].args[0]
+    assert create_args["email"] is source_email  # source email threaded to the booked event
 
 
 @pytest.mark.asyncio
@@ -971,7 +980,7 @@ async def test_cb_schedule_create_conflict_blocks(monkeypatch, reply_context):
 
     create_called = False
 
-    def _boom(_):
+    def _boom(*_a):
         nonlocal create_called
         create_called = True
         return "x"
@@ -999,7 +1008,7 @@ async def test_cb_schedule_create_api_failure_marks_failed(monkeypatch, reply_co
     monkeypatch.setattr(handlers.db, "get_calendar_event_by_id", lambda _: _detected_event())
     monkeypatch.setattr(handlers.scheduler, "has_conflict", lambda _: False)
 
-    def boom(_):
+    def boom(*_a):
         raise RuntimeError("calendar 500")
 
     monkeypatch.setattr(handlers.scheduler, "create_event", boom)
@@ -1026,7 +1035,7 @@ async def test_cb_schedule_create_idempotent_when_already_created(monkeypatch, r
     )
     create_called = False
 
-    def _boom(_):
+    def _boom(*_a):
         nonlocal create_called
         create_called = True
         return "x"


### PR DESCRIPTION
Closes #72

## Summary
- Booked Google Calendar events now include a `description`: the source email's `ai_summary` + a Gmail deep link (`https://mail.google.com/mail/u/0/#all/<thread_id>`) back to the thread.
- `scheduler.build_description(email)` + `build_event_body`/`create_event` take an optional `email` row; `description` is omitted when neither summary nor link exists (clean body preserved).
- The `/schedule` create-event handler looks up the source email and threads it into `create_event`.
- First quick win on the inbox-native scheduling ("Calendly replacement") track from Demo Day feedback.

## Test plan
- [x] New unit tests: description full / summary-only / link-only / absent + handler wiring
- [x] black + flake8 + bandit clean
- [x] pytest: 269 passed, 94.5% coverage
- [ ] Lint / Tests / Security workflows green on this PR