### PR TITLE
fix: schedule meeting requests tagged "Reply", not just "Schedule"

### DIFF
--- a/app/ai/meeting_detector.py
+++ b/app/ai/meeting_detector.py
@@ -20,6 +20,11 @@ _client = None
 
 CONFIDENCE_THRESHOLD = 0.6
 
+# A meeting request reliably lands in only these analyzer actions — "needs a reply"
+# and "is a meeting" aren't mutually exclusive, so gating on "Schedule" alone drops
+# real invites. Read/Archive/Flag stay excluded to bound the extra detector calls.
+SCHEDULABLE_ACTIONS = {"Schedule", "Reply"}
+
 MEETING_PROMPT = """Extract meeting/event details from this email and respond with JSON.
 
 EMAIL:
@@ -114,7 +119,7 @@ def maybe_detect_meeting(email_row: dict, analysis: dict) -> int | None:
     Returns the new event row id, or None if nothing was persisted (not a meeting,
     low confidence, detector failure, or already detected).
     """
-    if analysis.get("action_required") != "Schedule":
+    if analysis.get("action_required") not in SCHEDULABLE_ACTIONS:
         return None
     if db.get_calendar_event_by_email(email_row["id"]):
         return None

--- a/tests/unit/test_meeting_detector.py
+++ b/tests/unit/test_meeting_detector.py
@@ -169,15 +169,32 @@ def test_maybe_detect_meeting_persists_when_schedule_and_confident(mock_get_clie
 
 
 @patch.object(meeting_detector, "_get_client")
-def test_maybe_detect_meeting_skips_when_action_not_schedule(mock_get_client):
+def test_maybe_detect_meeting_skips_non_schedulable_action(mock_get_client):
+    """Read/Archive/Flag never carry a meeting — detector must not even run."""
     email_row_id = _insert_email("mt_skip_action")
+    email = _email_row(email_row_id)
+
+    new_id = meeting_detector.maybe_detect_meeting(email, {"action_required": "Archive"})
+
+    assert new_id is None
+    mock_get_client.assert_not_called()  # no detector call for non-schedulable actions
+    assert db.get_calendar_event_by_email(email_row_id) == []
+
+
+@patch.object(meeting_detector, "_get_client")
+def test_maybe_detect_meeting_persists_when_reply_and_meeting(mock_get_client):
+    """A meeting request tagged 'Reply' (not 'Schedule') must still be scheduled."""
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = _make_response(_meeting_payload())
+    mock_get_client.return_value = mock_client
+
+    email_row_id = _insert_email("mt_reply_meeting")
     email = _email_row(email_row_id)
 
     new_id = meeting_detector.maybe_detect_meeting(email, {"action_required": "Reply"})
 
-    assert new_id is None
-    assert db.get_calendar_event_by_email(email_row_id) == []
-    mock_get_client.assert_not_called()
+    assert new_id is not None
+    assert len(db.get_calendar_event_by_email(email_row_id)) == 1
 
 
 @patch.object(meeting_detector, "_get_client")


### PR DESCRIPTION
Closes #74

## Summary
- `maybe_detect_meeting` gated on `action_required == "Schedule"`, but the analyzer's enum is single-choice and a meeting invite usually also "needs a reply" → tagged `Reply` and silently dropped before the detector ran.
- Now gates on `SCHEDULABLE_ACTIONS = {"Schedule", "Reply"}`; the detector's own `is_meeting` + `CONFIDENCE_THRESHOLD` remain the real authority. `Read`/`Archive`/`Flag` stay excluded so detector cost stays bounded.
- Verified against 3 injected meeting emails: previously 1/3 scheduled (only the `Schedule`-tagged one); with this fix all 3 high-confidence meetings are detected.

## Test plan
- [x] New: `Reply`-tagged meeting persists; non-schedulable action (`Archive`) skips without calling the detector
- [x] black + flake8 + bandit clean
- [x] pytest: 270 passed, 94.7% coverage
- [ ] Lint / Tests / Security green on this PR