### PR TITLE
fix: surface calendar-create failures instead of failing silently

### DIFF
--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -554,7 +554,17 @@ async def cb_schedule_create(update: Update, context: ContextTypes.DEFAULT_TYPE)
         await update.effective_chat.send_message(f"Event already {event['status']}.")
         return
 
-    if scheduler.has_conflict(event):
+    # The freebusy call hits the Calendar API and can 403/timeout. It sits before
+    # the insert try/except, so guard it here — otherwise the error escapes into the
+    # background webhook task and the user gets no feedback at all. Status is left
+    # `detected` so the user can retry once the underlying issue is resolved.
+    try:
+        conflict = scheduler.has_conflict(event)
+    except Exception as exc:  # noqa: BLE001 — surface the calendar failure to the user
+        logger.exception("Conflict check failed for event=%s", event_id)
+        await update.effective_chat.send_message(f"Create failed: {exc}")
+        return
+    if conflict:
         await update.effective_chat.send_message(
             "⚠ Conflicts with an existing calendar event — not created. "
             "Tap Skip, or free up the slot and try again."
@@ -711,3 +721,21 @@ def register(application: Application) -> None:
     # an unrecognized /command, then any plain (non-command) text.
     application.add_handler(MessageHandler(filters.COMMAND, unknown_command))
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, fallback_text))
+
+    application.add_error_handler(on_error)
+
+
+async def on_error(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Last-resort handler: a crash in any handler must reach the user, not vanish.
+
+    Webhook updates are dispatched in a background task, so an unguarded exception
+    would only be logged server-side. This notifies the originating chat instead.
+    """
+    logger.error("Unhandled error processing update", exc_info=context.error)
+    chat = getattr(getattr(update, "effective_chat", None), "id", None)
+    if chat is None:
+        return
+    try:
+        await context.bot.send_message(chat, "⚠ Something went wrong — the error was logged.")
+    except Exception:  # noqa: BLE001 — never let the error handler raise
+        logger.exception("Failed to send error notice to chat=%s", chat)

--- a/tests/unit/test_telegram_handlers.py
+++ b/tests/unit/test_telegram_handlers.py
@@ -1049,6 +1049,72 @@ async def test_cb_schedule_create_idempotent_when_already_created(monkeypatch, r
 
 
 @pytest.mark.asyncio
+async def test_cb_schedule_create_surfaces_conflict_check_error(monkeypatch, reply_context):
+    """A Calendar error in the freebusy check must reach the user, not vanish."""
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+    monkeypatch.setattr(handlers.db, "get_calendar_event_by_id", lambda _: _detected_event())
+
+    def boom(_):
+        raise RuntimeError("Calendar API disabled")
+
+    monkeypatch.setattr(handlers.scheduler, "has_conflict", boom)
+
+    create_called = False
+
+    def _create(*_a):
+        nonlocal create_called
+        create_called = True
+        return "x"
+
+    monkeypatch.setattr(handlers.scheduler, "create_event", _create)
+    status_calls: list[tuple] = []
+    monkeypatch.setattr(
+        handlers.db, "update_calendar_event_status", lambda *a, **k: status_calls.append((a, k))
+    )
+
+    update = _make_callback_update("s:create:3")
+    await handlers.cb_schedule_create(update, reply_context)
+
+    assert create_called is False  # never reached the insert
+    assert status_calls == []  # status left 'detected' so the user can retry
+    assert "Create failed" in update.effective_chat.send_message.await_args_list[-1].args[0]
+
+
+@pytest.mark.asyncio
+async def test_on_error_notifies_originating_chat():
+    update = MagicMock()
+    update.effective_chat.id = 42
+    context = MagicMock()
+    context.error = RuntimeError("boom")
+    context.bot.send_message = AsyncMock()
+
+    await handlers.on_error(update, context)
+
+    context.bot.send_message.assert_awaited_once()
+    assert context.bot.send_message.await_args.args[0] == 42
+
+
+@pytest.mark.asyncio
+async def test_on_error_noop_without_chat():
+    update = MagicMock()
+    update.effective_chat = None
+    context = MagicMock()
+    context.error = RuntimeError("boom")
+    context.bot.send_message = AsyncMock()
+
+    await handlers.on_error(update, context)
+
+    context.bot.send_message.assert_not_called()
+
+
+def test_register_adds_error_handler():
+    app = MagicMock()
+    handlers.register(app)
+    app.add_error_handler.assert_called_once_with(handlers.on_error)
+
+
+@pytest.mark.asyncio
 async def test_cb_schedule_skip_marks_skipped(monkeypatch, reply_context):
     monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
     monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})


### PR DESCRIPTION
Closes #76

## Summary
- Tapping **Create** on `/schedule` did nothing when the Calendar API errored (freebusy 403 — the API was disabled in the GCP project). `scheduler.has_conflict()` ran *before* the insert try/except, so the exception escaped into the background webhook task and the user got **zero feedback**.
- Guard the conflict check so any calendar error replies `Create failed: <exc>`; status is left `detected` so the event stays retryable once the underlying issue (e.g. enabling the API) is resolved.
- Add a global `application.add_error_handler` safety net so **any** handler crash notifies the originating chat instead of vanishing.

## Reproduced
Live via Telegram Web (Chrome MCP): clicked Create → bot fully silent. Root-caused to the unguarded freebusy call + background-task error swallowing.

## Test plan
- [x] New: conflict-check error surfaces `Create failed` and leaves status untouched (retryable)
- [x] New: `on_error` notifies the chat / no-ops without a chat; `register` wires the error handler
- [x] black + flake8 + bandit clean
- [x] pytest: 274 passed, 94.6% coverage

## Note
The **trigger** (Calendar API disabled in GCP project `707808781459`) is a config fix the user applies in the Cloud console — this PR makes the failure *visible* rather than silent. Stale past-dated `/schedule` entries tracked separately in #77.