### PR TITLE
fix: book detected meeting times in the user's timezone, not UTC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,7 @@ TELEGRAM_OAUTH_CHECK_INTERVAL_HOURS=24
 
 # Root log level (W6-C) — INFO surfaces app + scheduler logs in journald/CloudWatch
 LOG_LEVEL=INFO
+
+# Timezone for detected meeting times (IANA name). A "2 PM" in an email is booked
+# at 2 PM in this zone. Defaults to UTC if unset. e.g. Asia/Jerusalem, America/New_York
+USER_TIMEZONE=UTC

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,7 @@ Listed in `.env.example`. Don't commit real values.
 | `TELEGRAM_OAUTH_CHECK_ENABLED` | `true`/`false` — auto-start the Gmail OAuth health monitor on startup (default `true`) |
 | `TELEGRAM_OAUTH_CHECK_INTERVAL_HOURS` | OAuth check interval in hours, minimum 5 minutes (default `24`) |
 | `LOG_LEVEL` | Root logger level set at startup so app + scheduler logs reach journald (default `INFO`) |
+| `USER_TIMEZONE` | IANA timezone a detected meeting wall-clock time is booked in (default `UTC`; e.g. `Asia/Jerusalem`) |
 
 `token.pickle` (Gmail OAuth) is generated on first auth and refreshed automatically. If `invalid_grant` errors appear, the refresh token has been revoked (Google revokes tokens for "Testing" apps after ~7 days of inactivity) — delete `token.pickle` and re-run `python -c "from app.gmail.auth import get_credentials; get_credentials()"` to re-auth.
 

--- a/app/ai/meeting_detector.py
+++ b/app/ai/meeting_detector.py
@@ -34,9 +34,10 @@ Received: {received}
 Body: {body}
 
 Resolve any natural-language dates (e.g. "next Tuesday at 3pm") against the
-Received date above. Always return ISO-8601 UTC for proposed_datetime, or null
-if no date can be confidently extracted. If the email is NOT a meeting/event
-request (e.g. it's a newsletter, FYI, or pure information), set is_meeting=false.
+Received date above. Return proposed_datetime in ISO-8601 using the date and time
+exactly as written in the email — do NOT convert time zones — or null if no date
+can be confidently extracted. If the email is NOT a meeting/event request (e.g.
+it's a newsletter, FYI, or pure information), set is_meeting=false.
 
 Respond ONLY with valid JSON (no markdown fences):
 {{

--- a/app/calendar/scheduler.py
+++ b/app/calendar/scheduler.py
@@ -6,11 +6,31 @@ layers. The live I/O stays behind `service.py`; everything here is unit-tested b
 mocking `service.check_busy` / `service.insert_event`.
 """
 
+import logging
+import os
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from app.calendar import service
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_DURATION_MINUTES = 30
+
+
+def _user_tz() -> ZoneInfo:
+    """The timezone a detected wall-clock time is assumed to be in.
+
+    Read lazily so it picks up `load_dotenv()`. Defaults to UTC; an unknown name
+    falls back to UTC rather than crashing the create flow.
+    """
+    name = os.getenv("USER_TIMEZONE", "UTC")
+    try:
+        return ZoneInfo(name)
+    except (ZoneInfoNotFoundError, ValueError):
+        logger.warning("Invalid USER_TIMEZONE=%r; falling back to UTC", name)
+        return ZoneInfo("UTC")
+
 
 _THREAD_URL = "https://mail.google.com/mail/u/0/#all/{thread_id}"
 
@@ -32,7 +52,9 @@ def event_window(event_row: dict) -> tuple[str, str] | None:
     except ValueError:
         return None
     if start.tzinfo is None:
-        start = start.replace(tzinfo=timezone.utc)
+        # The detector stores the wall-clock time as written in the email; interpret
+        # it in the user's timezone, not UTC, so "2 PM" books at 2 PM locally.
+        start = start.replace(tzinfo=_user_tz())
 
     duration = event_row.get("duration_minutes") or DEFAULT_DURATION_MINUTES
     end = start + timedelta(minutes=duration)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ python-dateutil
 httpx
 python-telegram-bot>=22.7
 apscheduler>=3.11.2
+tzdata

--- a/tests/unit/test_calendar_scheduler.py
+++ b/tests/unit/test_calendar_scheduler.py
@@ -33,6 +33,20 @@ def test_event_window_defaults_duration_when_null():
     assert end == "2026-05-19T15:30:00Z"  # DEFAULT_DURATION_MINUTES = 30
 
 
+def test_event_window_interprets_time_in_user_timezone(monkeypatch):
+    """A 15:00 wall-clock time in a UTC+3 zone is the 12:00Z absolute instant."""
+    monkeypatch.setenv("USER_TIMEZONE", "Etc/GMT-3")  # fixed UTC+3, no DST
+    start, end = scheduler.event_window(_row())
+    assert start == "2026-05-19T12:00:00Z"
+    assert end == "2026-05-19T13:00:00Z"
+
+
+def test_event_window_unknown_timezone_falls_back_to_utc(monkeypatch):
+    monkeypatch.setenv("USER_TIMEZONE", "Not/AZone")
+    start, _ = scheduler.event_window(_row())
+    assert start == "2026-05-19T15:00:00Z"
+
+
 def test_event_window_none_without_date_or_time():
     assert scheduler.event_window(_row(event_date=None)) is None
     assert scheduler.event_window(_row(event_time=None)) is None


### PR DESCRIPTION
Closes #79

## Summary
- A "2 PM" meeting was booked at 17:00 (+03:00): the detector stores the wall-clock time as written (`14:00`) and `scheduler.event_window` interpreted it as **UTC**, shifting it by the user's offset.
- Now interpret the stored naive date/time in a configured **`USER_TIMEZONE`** (IANA name, default `UTC`) before converting to the absolute instant sent to Google — so 2 PM books at 2 PM locally.
- Updated the detector prompt to return the time exactly as written (no UTC relabeling).
- Added `tzdata` so `zoneinfo` resolves IANA zones on Windows / minimal Linux.

## Test plan
- [x] New: 15:00 wall-clock in a UTC+3 zone → `12:00Z`; unknown zone falls back to UTC
- [x] black + flake8 + bandit clean
- [x] pytest: 276 passed, 94.7% coverage

## Action item (user)
Set `USER_TIMEZONE=Asia/Jerusalem` in the server `.env` (default `UTC` preserves old behavior). Without it the times stay UTC.