### PR TITLE
fix(ux): compact, scannable /inbox and /unread cards

### DIFF
--- a/app/telegram/formatting.py
+++ b/app/telegram/formatting.py
@@ -1,5 +1,7 @@
 """Telegram MarkdownV2 escaping + email/analysis renderers + 4096-char chunking."""
 
+from email.utils import parseaddr
+
 # Per https://core.telegram.org/bots/api#markdownv2-style — these MUST be escaped
 # anywhere they appear in user-supplied text, otherwise the bot API returns
 # "Bad Request: can't parse entities".
@@ -27,12 +29,34 @@ def _priority_emoji(urgency: int | None) -> str:
     return "🟢"
 
 
+def sender_display_name(raw_sender: str | None) -> str:
+    """The human-friendly sender: display name when present, else the bare address.
+
+    Drops the `Name <addr>` duplication that made list rows long and auto-linked.
+    """
+    name, addr = parseaddr(raw_sender or "")
+    return name or addr or (raw_sender or "Unknown sender")
+
+
+def _truncate(text: str, limit: int) -> str:
+    """Trim to `limit` chars with an ellipsis so list rows stay one line each."""
+    text = (text or "").strip()
+    return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
+
+
+_SUBJECT_LIMIT = 70
+_PREVIEW_LIMIT = 110
+
+
 def format_unread_entry(email: dict, index: int) -> str:
-    """Render one Gmail-fetched email as a numbered MarkdownV2 block."""
-    sender = escape_markdown_v2(email.get("sender") or "Unknown sender")
-    subject = escape_markdown_v2(email.get("subject") or "(no subject)")
-    snippet = escape_markdown_v2(email.get("snippet") or "")
-    return f"*{index}\\.* {sender}\n*Subject:* {subject}\n{snippet}"
+    """Render one Gmail-fetched email as a compact numbered MarkdownV2 card."""
+    name = escape_markdown_v2(sender_display_name(email.get("sender")))
+    subject = escape_markdown_v2(_truncate(email.get("subject") or "(no subject)", _SUBJECT_LIMIT))
+    snippet = escape_markdown_v2(_truncate(email.get("snippet") or "", _PREVIEW_LIMIT))
+    lines = [f"*{index}\\.* *{name}*", f"✉️ {subject}"]
+    if snippet:
+        lines.append(f"   ↳ {snippet}")
+    return "\n".join(lines)
 
 
 def _id_prefix(row: dict) -> str:
@@ -60,12 +84,15 @@ def format_analysis_entry(email: dict, analysis: dict) -> str:
 
 
 def format_inbox_entry(row: dict) -> str:
-    """Render one analyzed-email DB row as a MarkdownV2 block keyed by its row id."""
-    sender = escape_markdown_v2(row.get("sender") or "Unknown sender")
-    subject = escape_markdown_v2(row.get("subject") or "(no subject)")
-    summary = escape_markdown_v2(row.get("ai_summary") or "")
+    """Render one analyzed-email DB row as a compact MarkdownV2 card keyed by row id."""
+    name = escape_markdown_v2(sender_display_name(row.get("sender")))
+    subject = escape_markdown_v2(_truncate(row.get("subject") or "(no subject)", _SUBJECT_LIMIT))
+    summary = escape_markdown_v2(_truncate(row.get("ai_summary") or "", _PREVIEW_LIMIT))
     emoji = _priority_emoji(row.get("urgency_score"))
-    return f"{emoji} {_id_prefix(row)} {sender} — {subject}\n{summary}"
+    lines = [f"{emoji} {_id_prefix(row)} · *{name}*", f"✉️ {subject}"]
+    if summary:
+        lines.append(f"   ↳ {summary}")
+    return "\n".join(lines)
 
 
 _TONE_LABEL = {

--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -5,7 +5,13 @@ import logging
 import os
 from functools import wraps
 
-from telegram import BotCommand, InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram import (
+    BotCommand,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    LinkPreviewOptions,
+    Update,
+)
 from telegram.constants import ChatAction, ParseMode
 from telegram.ext import (
     Application,
@@ -150,7 +156,13 @@ async def _send_chunks(update: Update, blocks: list[str], empty_message: str) ->
         await update.message.reply_text(empty_message)
         return
     for chunk in chunk_messages(blocks):
-        await update.message.reply_text(chunk, parse_mode=ParseMode.MARKDOWN_V2)
+        # Disable previews so a URL in a summary/snippet doesn't balloon into a
+        # full-width image that hijacks the list.
+        await update.message.reply_text(
+            chunk,
+            parse_mode=ParseMode.MARKDOWN_V2,
+            link_preview_options=LinkPreviewOptions(is_disabled=True),
+        )
 
 
 @authorized_only

--- a/tests/unit/test_telegram_formatting.py
+++ b/tests/unit/test_telegram_formatting.py
@@ -7,7 +7,36 @@ from app.telegram.formatting import (
     format_inbox_entry,
     format_notification,
     format_unread_entry,
+    sender_display_name,
 )
+
+
+def test_sender_display_name_prefers_display_name():
+    assert sender_display_name("Qodo <no-reply@qodo.com>") == "Qodo"
+
+
+def test_sender_display_name_falls_back_to_bare_address():
+    assert sender_display_name("no-reply@qodo.com") == "no-reply@qodo.com"
+
+
+def test_sender_display_name_handles_none():
+    assert sender_display_name(None) == "Unknown sender"
+
+
+def test_format_inbox_entry_drops_raw_address_and_truncates_long_summary():
+    row = {
+        "id": 3,
+        "sender": "Qodo <no-reply@qodo.com>",
+        "subject": "Thank you",
+        "ai_summary": "x" * 200,
+        "urgency_score": 5,
+    }
+    block = format_inbox_entry(row)
+    assert "*Qodo*" in block
+    assert "no-reply@qodo" not in block  # raw address gone
+    assert "✉️ Thank you" in block
+    assert "…" in block  # long summary truncated
+    assert "↳" in block
 
 
 def test_escape_markdown_v2_passes_plain_text_through():
@@ -34,11 +63,16 @@ def test_escape_markdown_v2_escapes_email_address_dot():
 
 
 def test_format_unread_entry_happy_path():
-    email = {"sender": "alice@example.com", "subject": "Hi", "snippet": "Just checking in"}
+    email = {
+        "sender": "Alice <alice@example.com>",
+        "subject": "Hi",
+        "snippet": "Just checking in",
+    }
     block = format_unread_entry(email, 1)
     assert "*1\\.*" in block
-    assert "alice@example\\.com" in block
-    assert "*Subject:* Hi" in block
+    assert "*Alice*" in block  # display name, not the raw <addr>
+    assert "alice@example" not in block  # raw address dropped
+    assert "✉️ Hi" in block
     assert "Just checking in" in block
 
 


### PR DESCRIPTION
Closes #81

## Summary
Live Chrome-MCP UX test showed `/inbox` and `/unread` were hard to read. This reworks them into compact 3-line cards.

- **`sender_display_name`** — show the display name, drop the `Name <raw@addr>` duplication that auto-linked and wrapped.
- **Truncation** — subject ≤70, summary/snippet ≤110 chars, so each email is a scannable card, not a paragraph.
- **3-line card** — `priority + #id + name` / `✉️ subject` / `↳ one-line summary`.
- **`_send_chunks`: disable link previews** (`LinkPreviewOptions(is_disabled=True)`) so a URL in a summary no longer balloons into a full-width preview image. Also benefits `/analyze`.

## Test plan
- [x] New: `sender_display_name` variants; inbox card drops raw address + truncates
- [x] Updated unread happy-path for the new card layout
- [x] black + flake8 + bandit clean
- [x] pytest: 280 passed, 94.7% coverage
- [ ] Re-verify live via MCP after deploy

## Follow-up (not in this PR)
`/analyze` and push notifications still show the raw `Name <addr>`; same `sender_display_name` could be applied for consistency.