### PR TITLE
feat(ux): /email detail view + list volume tuning + richer inbox cards

### DIFF
--- a/app/database/db.py
+++ b/app/database/db.py
@@ -209,6 +209,18 @@ def get_recent_emails(limit: int = 50) -> list[dict]:
         conn.close()
 
 
+def count_analyzed_emails() -> int:
+    """Total analyzed emails, for the /inbox "showing N of M" footer."""
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) AS n FROM emails WHERE processed_at IS NOT NULL"
+        ).fetchone()
+        return int(row["n"]) if row else 0
+    finally:
+        conn.close()
+
+
 def get_unprocessed_emails() -> list[dict]:
     """Get emails that haven't been analyzed yet."""
     conn = get_connection()

--- a/app/telegram/formatting.py
+++ b/app/telegram/formatting.py
@@ -1,6 +1,9 @@
 """Telegram MarkdownV2 escaping + email/analysis renderers + 4096-char chunking."""
 
+from datetime import datetime
 from email.utils import parseaddr
+
+from dateutil import parser as date_parser
 
 # Per https://core.telegram.org/bots/api#markdownv2-style — these MUST be escaped
 # anywhere they appear in user-supplied text, otherwise the bot API returns
@@ -44,6 +47,38 @@ def _truncate(text: str, limit: int) -> str:
     return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
 
 
+_ACTION_GLYPH = {
+    "Reply": "✍️",
+    "Schedule": "📅",
+    "Read": "📖",
+    "Archive": "🗄",
+    "Flag": "🚩",
+}
+
+
+def _action_glyph(action: str | None) -> str:
+    """Glyph for an analyzer action_required; empty string when unknown."""
+    return _ACTION_GLYPH.get(action or "", "")
+
+
+def _short_time(date_str: str | None, now: datetime | None = None, full: bool = False) -> str:
+    """Parse a received/created timestamp into a short label; '' if unparseable.
+
+    Today → `HH:MM`, otherwise `DD Mon`. `full` gives `DD Mon YYYY, HH:MM` for the
+    detail view. Naive comparison (tz dropped) — good enough for a recency hint.
+    """
+    if not date_str:
+        return ""
+    try:
+        dt = date_parser.parse(date_str).replace(tzinfo=None)
+    except (ValueError, OverflowError, TypeError):
+        return ""
+    if full:
+        return dt.strftime("%d %b %Y, %H:%M")
+    now = now or datetime.now()
+    return dt.strftime("%H:%M") if dt.date() == now.date() else dt.strftime("%d %b")
+
+
 _SUBJECT_LIMIT = 70
 _PREVIEW_LIMIT = 110
 
@@ -84,15 +119,58 @@ def format_analysis_entry(email: dict, analysis: dict) -> str:
 
 
 def format_inbox_entry(row: dict) -> str:
-    """Render one analyzed-email DB row as a compact MarkdownV2 card keyed by row id."""
+    """Render one analyzed-email DB row as a compact MarkdownV2 card keyed by row id.
+
+    Line 1 carries the decision signals: priority, id, sender, a recency hint, and
+    the suggested-action glyph. Lines 2-3 are subject + a one-line summary.
+    """
     name = escape_markdown_v2(sender_display_name(row.get("sender")))
     subject = escape_markdown_v2(_truncate(row.get("subject") or "(no subject)", _SUBJECT_LIMIT))
     summary = escape_markdown_v2(_truncate(row.get("ai_summary") or "", _PREVIEW_LIMIT))
     emoji = _priority_emoji(row.get("urgency_score"))
-    lines = [f"{emoji} {_id_prefix(row)} · *{name}*", f"✉️ {subject}"]
+
+    header = f"{emoji} {_id_prefix(row)} · *{name}*"
+    when = _short_time(row.get("received_date") or row.get("created_at"))
+    if when:
+        header += f" · {escape_markdown_v2(when)}"
+    glyph = _action_glyph(row.get("action_required"))
+    if glyph:
+        header += f" · {glyph}"
+
+    lines = [header, f"✉️ {subject}"]
     if summary:
         lines.append(f"   ↳ {summary}")
     return "\n".join(lines)
+
+
+def format_email_detail(row: dict) -> str:
+    """Render the full single-email detail view (untruncated) for `/email <id>`."""
+    emoji = _priority_emoji(row.get("urgency_score"))
+    urgency = row.get("urgency_score")
+    urgency_str = escape_markdown_v2(f"{urgency}/10" if urgency is not None else "n/a")
+    sender = escape_markdown_v2(row.get("sender") or "Unknown sender")
+    when = escape_markdown_v2(
+        _short_time(row.get("received_date") or row.get("created_at"), full=True)
+    )
+    category = escape_markdown_v2(row.get("category") or "Unknown")
+    action = row.get("action_required")
+    subject = escape_markdown_v2(row.get("subject") or "(no subject)")
+    summary = escape_markdown_v2(row.get("ai_summary") or "(not analyzed yet — run /analyze)")
+
+    meta = f"📂 {category}"
+    if when:
+        meta = f"🕑 {when}   {meta}"
+    glyph = _action_glyph(action)
+    if action:
+        meta += f"   {glyph} {escape_markdown_v2(action)}"
+
+    return (
+        f"{emoji} {_id_prefix(row)} · *urgency {urgency_str}*\n\n"
+        f"👤 {sender}\n"
+        f"{meta}\n\n"
+        f"✉️ *{subject}*\n\n"
+        f"📝 {summary}"
+    )
 
 
 _TONE_LABEL = {

--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -38,12 +38,15 @@ from app.telegram.formatting import (
     escape_markdown_v2,
     format_analysis_entry,
     format_drafts_message,
+    format_email_detail,
     format_inbox_entry,
     format_unread_entry,
 )
 
-INBOX_DEFAULT_LIMIT = 10
-UNREAD_DEFAULT_LIMIT = 20
+INBOX_DEFAULT_LIMIT = 6
+UNREAD_DEFAULT_LIMIT = 8
+LIST_MAX_LIMIT = 50
+_GMAIL_THREAD_URL = "https://mail.google.com/mail/u/0/#all/{thread_id}"
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +56,7 @@ WELCOME = (
     "/unread - list unread emails\n"
     "/analyze - run AI analysis on unprocessed emails\n"
     "/inbox - show last analyzed emails\n"
+    "/email <id> - open one email in full with actions\n"
     "/reply <id> - draft a reply to an email\n"
     "/schedule - create calendar events from detected meetings\n"
     "/agent <text> - run a natural-language request through the agent\n"
@@ -70,6 +74,7 @@ COMMANDS: list[BotCommand] = [
     BotCommand("unread", "list unread emails from gmail"),
     BotCommand("analyze", "analyze emails with claude"),
     BotCommand("inbox", "show recently analyzed emails"),
+    BotCommand("email", "open one email in full — usage: /email <id>"),
     BotCommand("reply", "draft replies — usage: /reply <id>"),
     BotCommand("schedule", "create calendar events from detected meetings"),
     BotCommand("agent", "run a natural-language request through the agent"),
@@ -165,22 +170,33 @@ async def _send_chunks(update: Update, blocks: list[str], empty_message: str) ->
         )
 
 
+def _list_limit(context: ContextTypes.DEFAULT_TYPE, default: int) -> int:
+    """Optional first arg as a count, clamped to [1, LIST_MAX_LIMIT]; else default."""
+    args = getattr(context, "args", None) or []
+    if args and args[0].isdigit():
+        return max(1, min(int(args[0]), LIST_MAX_LIMIT))
+    return default
+
+
 @authorized_only
 async def unread(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Fetch unread emails from Gmail and reply with a numbered list."""
     await _typing(update)
+    limit = _list_limit(context, UNREAD_DEFAULT_LIMIT)
     try:
-        emails = gmail_fetch_recent(max_results=UNREAD_DEFAULT_LIMIT, unread_only=True)
+        emails = gmail_fetch_recent(max_results=limit, unread_only=True)
     except RuntimeError as exc:
         logger.exception("Gmail fetch failed for /unread")
         await update.message.reply_text(f"Gmail error: {exc}")
         return
     blocks = [format_unread_entry(email, i + 1) for i, email in enumerate(emails)]
     if blocks:
-        blocks.append(
-            "_These numbers are just list positions, not reply ids\\. "
-            "To reply, run /analyze then use the \\#id shown by /inbox\\._"
-        )
+        note = "list positions, not reply ids — run /analyze then /inbox"
+        footer = f"Showing {len(emails)} unread · {note}"
+        if len(emails) >= limit and limit < LIST_MAX_LIMIT:
+            more = min(limit * 2, LIST_MAX_LIMIT)
+            footer = f"Showing {len(emails)} · /unread {more} for more · {note}"
+        blocks.append(escape_markdown_v2(footer))
     await _send_chunks(update, blocks, "No unread emails.")
 
 
@@ -226,12 +242,56 @@ async def analyze(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 async def inbox(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Show the most recent analyzed emails from the DB with priority indicators."""
     await _typing(update)
-    rows = db.get_recent_emails(limit=INBOX_DEFAULT_LIMIT)
+    limit = _list_limit(context, INBOX_DEFAULT_LIMIT)
+    rows = db.get_recent_emails(limit=limit)
     analyzed = [row for row in rows if row.get("processed_at")]
     blocks = [format_inbox_entry(row) for row in analyzed]
     if blocks:
-        blocks.append("_Tip:_ use `/reply <id>` with one of the `#` numbers above\\.")
+        total = db.count_analyzed_emails()
+        footer = f"Showing {len(analyzed)} of {total} · open one with /email <id>"
+        if total > len(analyzed) and limit < LIST_MAX_LIMIT:
+            footer = (
+                f"Showing {len(analyzed)} of {total} · /inbox {min(limit * 2, LIST_MAX_LIMIT)} "
+                f"for more · open one with /email <id>"
+            )
+        blocks.append(escape_markdown_v2(footer))
     await _send_chunks(update, blocks, "No analyzed emails yet.")
+
+
+def _build_email_detail_keyboard(row: dict) -> InlineKeyboardMarkup:
+    """Reply / Mark Done / Open-in-Gmail buttons for the /email detail view."""
+    email_id = row["id"]
+    buttons = [
+        InlineKeyboardButton("✍ Reply", callback_data=f"e:reply:{email_id}"),
+        InlineKeyboardButton("✅ Mark Done", callback_data=f"e:done:{email_id}"),
+    ]
+    thread_id = row.get("thread_id")
+    if thread_id:
+        buttons.append(
+            InlineKeyboardButton(
+                "🔗 Open in Gmail", url=_GMAIL_THREAD_URL.format(thread_id=thread_id)
+            )
+        )
+    return InlineKeyboardMarkup([buttons])
+
+
+@authorized_only
+async def email_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """`/email <id>` — open one email in full with Reply / Done / Open-in-Gmail."""
+    args = context.args or []
+    if not args or not args[0].isdigit():
+        await update.effective_chat.send_message("Usage: /email <id> (the #id shown by /inbox)")
+        return
+    row = db.get_email_by_row_id(int(args[0]))
+    if not row:
+        await update.effective_chat.send_message(f"No email with id {args[0]}.")
+        return
+    await update.effective_chat.send_message(
+        format_email_detail(row),
+        parse_mode=ParseMode.MARKDOWN_V2,
+        reply_markup=_build_email_detail_keyboard(row),
+        link_preview_options=LinkPreviewOptions(is_disabled=True),
+    )
 
 
 _REPLY_TONES = ("professional", "friendly", "brief")
@@ -495,6 +555,29 @@ async def cb_notify_done(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
 
 @authorized_only
+async def cb_email_reply(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """/email detail → ✍ Reply: run the shared draft flow."""
+    query = update.callback_query
+    await query.answer("Drafting…")
+    parsed = _parse_callback(query.data or "", prefix="e")
+    if parsed is None or parsed[0] != "reply":
+        return
+    await _run_reply_flow(update, parsed[1])
+
+
+@authorized_only
+async def cb_email_done(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """/email detail → ✅ Mark Done: archive+read in DB."""
+    query = update.callback_query
+    await query.answer("Done")
+    parsed = _parse_callback(query.data or "", prefix="e")
+    if parsed is None or parsed[0] != "done":
+        return
+    db.mark_email_done(parsed[1])
+    await update.effective_chat.send_message("✅ Marked done.")
+
+
+@authorized_only
 async def pause_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Stop the push scheduler."""
     telegram_push.pause()
@@ -710,6 +793,7 @@ def register(application: Application) -> None:
     application.add_handler(CommandHandler("unread", unread))
     application.add_handler(CommandHandler("analyze", analyze))
     application.add_handler(CommandHandler("inbox", inbox))
+    application.add_handler(CommandHandler("email", email_command))
     application.add_handler(CommandHandler("reply", reply_command))
     application.add_handler(CommandHandler("schedule", schedule_command))
     application.add_handler(CommandHandler("agent", agent_command))
@@ -726,6 +810,8 @@ def register(application: Application) -> None:
     application.add_handler(CallbackQueryHandler(cb_notify_done, pattern=r"^n:done:\d+$"))
     application.add_handler(CallbackQueryHandler(cb_schedule_create, pattern=r"^s:create:\d+$"))
     application.add_handler(CallbackQueryHandler(cb_schedule_skip, pattern=r"^s:skip:\d+$"))
+    application.add_handler(CallbackQueryHandler(cb_email_reply, pattern=r"^e:reply:\d+$"))
+    application.add_handler(CallbackQueryHandler(cb_email_done, pattern=r"^e:done:\d+$"))
     application.add_handler(CallbackQueryHandler(cb_agent_approve, pattern=r"^a:approve$"))
     application.add_handler(CallbackQueryHandler(cb_agent_cancel, pattern=r"^a:cancel$"))
 

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -146,6 +146,24 @@ def test_get_unprocessed_emails_excludes_analyzed():
     assert "done" not in unprocessed_ids
 
 
+def test_count_analyzed_emails_counts_only_processed():
+    for gid in ("c_raw", "c_done1", "c_done2"):
+        db.insert_email(
+            {
+                "id": gid,
+                "thread_id": "t",
+                "sender": "a@a",
+                "subject": "s",
+                "snippet": "",
+                "date": "",
+            }
+        )
+    for gid in ("c_done1", "c_done2"):
+        db.update_analysis(gid, {"summary": "x", "category": "Work", "urgency_score": 1})
+
+    assert db.count_analyzed_emails() == 2
+
+
 def _make_email(gmail_id: str = "msg_d") -> int:
     """Insert an email and return its sqlite rowid."""
     return db.insert_email(

--- a/tests/unit/test_telegram_formatting.py
+++ b/tests/unit/test_telegram_formatting.py
@@ -1,14 +1,58 @@
 """Tests for app/telegram/formatting.py — escaping, renderers, chunking."""
 
+from datetime import datetime
+
 from app.telegram.formatting import (
     chunk_messages,
     escape_markdown_v2,
     format_analysis_entry,
+    format_email_detail,
     format_inbox_entry,
     format_notification,
     format_unread_entry,
     sender_display_name,
 )
+from app.telegram import formatting
+
+
+def test_short_time_today_shows_clock(monkeypatch):
+    now = datetime(2026, 5, 10, 18, 0, 0)
+    assert formatting._short_time("Sun, 10 May 2026 09:30:00 +0000", now=now) == "09:30"
+
+
+def test_short_time_other_day_shows_date(monkeypatch):
+    now = datetime(2026, 5, 12, 0, 0, 0)
+    assert formatting._short_time("Sun, 10 May 2026 09:30:00 +0000", now=now) == "10 May"
+
+
+def test_short_time_unparseable_returns_empty():
+    assert formatting._short_time("not a date") == ""
+    assert formatting._short_time(None) == ""
+
+
+def test_format_inbox_entry_shows_action_glyph():
+    row = {"id": 1, "sender": "A", "subject": "s", "ai_summary": "x", "action_required": "Schedule"}
+    assert "📅" in format_inbox_entry(row)
+
+
+def test_format_email_detail_has_full_fields_and_no_truncation():
+    row = {
+        "id": 9,
+        "sender": "Boss <boss@corp.com>",
+        "subject": "Q3 plan",
+        "ai_summary": "y" * 200,
+        "urgency_score": 9,
+        "category": "Work",
+        "action_required": "Reply",
+        "received_date": "Mon, 10 May 2026 09:00:00 +0000",
+    }
+    block = format_email_detail(row)
+    assert "*\\#9*" in block
+    assert "boss@corp\\.com" in block  # full address kept in detail
+    assert "Work" in block
+    assert "y" * 200 in block  # summary NOT truncated in the detail view
+    assert "…" not in block
+    assert "✉️ *Q3 plan*" in block
 
 
 def test_sender_display_name_prefers_display_name():

--- a/tests/unit/test_telegram_handlers.py
+++ b/tests/unit/test_telegram_handlers.py
@@ -174,16 +174,17 @@ async def test_inbox_lists_analyzed_rows(monkeypatch, authorized_update):
         },
     ]
     monkeypatch.setattr(handlers.db, "get_recent_emails", lambda limit: rows)
+    monkeypatch.setattr(handlers.db, "count_analyzed_emails", lambda: 2)
     await handlers.inbox(authorized_update, None)
     text = _all_reply_texts(authorized_update)
     assert "alice@example\\.com" in text
     assert "bob@example\\.com" in text
     assert "skip@example\\.com" not in text
-    assert "\\#4" in text  # row ids visible so /reply target is obvious
+    assert "\\#4" in text  # row ids visible so /email target is obvious
     assert "\\#6" in text
     assert "🔴" in text
     assert "🟢" in text
-    assert "/reply <id>" in text  # helper tip footer
+    assert "/email" in text  # footer points to the detail view
 
 
 @pytest.mark.asyncio
@@ -191,6 +192,89 @@ async def test_inbox_replies_empty_when_none_analyzed(monkeypatch, authorized_up
     monkeypatch.setattr(handlers.db, "get_recent_emails", lambda limit: [])
     await handlers.inbox(authorized_update, None)
     authorized_update.message.reply_text.assert_awaited_once_with("No analyzed emails yet.")
+
+
+@pytest.mark.asyncio
+async def test_inbox_respects_count_arg(monkeypatch, authorized_update, reply_context):
+    captured = {}
+
+    def fake_recent(limit):
+        captured["limit"] = limit
+        return []
+
+    monkeypatch.setattr(handlers.db, "get_recent_emails", fake_recent)
+    reply_context.args = ["15"]
+    await handlers.inbox(authorized_update, reply_context)
+    assert captured["limit"] == 15
+
+
+@pytest.mark.asyncio
+async def test_email_command_requires_id(authorized_update, reply_context):
+    await handlers.email_command(authorized_update, reply_context)
+    assert "Usage: /email" in _all_reply_texts(authorized_update)
+
+
+@pytest.mark.asyncio
+async def test_email_command_not_found(monkeypatch, authorized_update, reply_context):
+    monkeypatch.setattr(handlers.db, "get_email_by_row_id", lambda _: None)
+    reply_context.args = ["999"]
+    await handlers.email_command(authorized_update, reply_context)
+    assert "No email with id 999" in _all_reply_texts(authorized_update)
+
+
+@pytest.mark.asyncio
+async def test_email_command_shows_detail_with_buttons(
+    monkeypatch, authorized_update, reply_context
+):
+    row = {
+        "id": 5,
+        "sender": "Boss <boss@corp.com>",
+        "subject": "Q3 plan",
+        "ai_summary": "summary",
+        "urgency_score": 7,
+        "category": "Work",
+        "action_required": "Reply",
+        "thread_id": "th1",
+    }
+    monkeypatch.setattr(handlers.db, "get_email_by_row_id", lambda _: row)
+    reply_context.args = ["5"]
+    await handlers.email_command(authorized_update, reply_context)
+
+    call = authorized_update.effective_chat.send_message.await_args_list[-1]
+    assert "Q3 plan" in call.args[0]
+    buttons = [b for kb_row in call.kwargs["reply_markup"].inline_keyboard for b in kb_row]
+    labels = [b.text for b in buttons]
+    assert any("Reply" in label for label in labels)
+    assert any("Done" in label for label in labels)
+    assert any(b.url and "th1" in b.url for b in buttons)  # Open-in-Gmail link
+
+
+@pytest.mark.asyncio
+async def test_cb_email_reply_runs_flow(monkeypatch, reply_context):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+    flow_calls: list = []
+
+    async def fake_flow(update, email_id):
+        flow_calls.append(email_id)
+
+    monkeypatch.setattr(handlers, "_run_reply_flow", fake_flow)
+    update = _make_callback_update("e:reply:5")
+    await handlers.cb_email_reply(update, reply_context)
+    assert flow_calls == [5]
+
+
+@pytest.mark.asyncio
+async def test_cb_email_done_marks_done(monkeypatch, reply_context):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+    done_calls: list = []
+    monkeypatch.setattr(handlers.db, "mark_email_done", lambda eid: done_calls.append(eid))
+    update = _make_callback_update("e:done:5")
+    await handlers.cb_email_done(update, reply_context)
+    assert done_calls == [5]
+    sent = update.effective_chat.send_message.await_args_list[-1].args[0]
+    assert "done" in sent.lower()
 
 
 def _analyzed_email_row(row_id: int = 5) -> dict:
@@ -841,7 +925,7 @@ async def test_cb_notify_done_ignores_malformed_callback(monkeypatch, reply_cont
 
 @pytest.mark.asyncio
 async def test_set_bot_commands_registers_all_commands():
-    """All 9 user-facing commands must be sent to Telegram's set_my_commands."""
+    """All user-facing commands must be sent to Telegram's set_my_commands."""
     application = MagicMock()
     application.bot.set_my_commands = AsyncMock()
 
@@ -856,6 +940,7 @@ async def test_set_bot_commands_registers_all_commands():
         "unread",
         "analyze",
         "inbox",
+        "email",
         "reply",
         "schedule",
         "agent",


### PR DESCRIPTION
Closes #83

## Summary
The "reading experience" pass from the live MCP UX review.

- **`/email <id>`** — full single-email view (untruncated summary + sender + date + category + urgency + suggested action) with **✍ Reply / ✅ Mark Done / 🔗 Open in Gmail** buttons. Reply reuses `_run_reply_flow`; Done reuses `db.mark_email_done`; Open-in-Gmail is a URL button to the thread.
- **Volume** — list defaults lowered (inbox 10→6, unread 20→8); optional `/inbox <n>` / `/unread <n>` count (capped at 50); footer `Showing N of M · /inbox <n> for more · open one with /email <id>`.
- **Richer cards** — `/inbox` line 1 gains a recency hint + an action glyph (✍️/📅/📖/🗄/🚩) from `action_required`.
- `db.count_analyzed_emails()` for the footer total; `/email` added to WELCOME + `/` command popup.

## Test plan
- [x] New: `_short_time`, action glyph, `format_email_detail`; `/email` found/bad-id/not-found; `cb_email_reply`/`cb_email_done`; volume arg; `count_analyzed_emails`
- [x] black + flake8 + bandit clean
- [x] pytest: 292 passed, 94.7% coverage
- [ ] Re-verify live via MCP after deploy