### PR TITLE
fix(ux): render /agent replies as MarkdownV2 (not raw markdown)

### DIFF
--- a/app/telegram/formatting.py
+++ b/app/telegram/formatting.py
@@ -1,5 +1,6 @@
 """Telegram MarkdownV2 escaping + email/analysis renderers + 4096-char chunking."""
 
+import re
 from datetime import datetime
 from email.utils import parseaddr
 
@@ -19,6 +20,55 @@ def escape_markdown_v2(text: str | None) -> str:
     if not text:
         return ""
     return text.translate(_MD_V2_TRANSLATION)
+
+
+_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
+_HEADER_RE = re.compile(r"^\s*#{1,6}\s+(.*)$")
+_BULLET_RE = re.compile(r"^(\s*)[-*]\s+(.*)$")
+
+
+def _md2_inline(text: str) -> str:
+    """Escape a single line for MarkdownV2, rendering **bold** as *bold*."""
+    parts: list[str] = []
+    last = 0
+    for m in _BOLD_RE.finditer(text):
+        parts.append(escape_markdown_v2(text[last : m.start()]))
+        parts.append("*" + escape_markdown_v2(m.group(1)) + "*")
+        last = m.end()
+    parts.append(escape_markdown_v2(text[last:]))
+    return "".join(parts)
+
+
+def agent_text_to_md2(text: str | None) -> str:
+    """Convert the agent's standard-Markdown reply to Telegram MarkdownV2.
+
+    `## headers` and `**bold**` become bold, `-`/`*` bullets become `•`, and
+    everything else is escaped. Caller should fall back to `strip_markdown` on a
+    MarkdownV2 send error.
+    """
+    out: list[str] = []
+    for line in (text or "").split("\n"):
+        header = _HEADER_RE.match(line)
+        if header:
+            out.append("*" + _md2_inline(header.group(1)) + "*")
+            continue
+        bullet = _BULLET_RE.match(line)
+        if bullet:
+            out.append(f"{bullet.group(1)}• {_md2_inline(bullet.group(2))}")
+            continue
+        out.append(_md2_inline(line))
+    return "\n".join(out)
+
+
+def strip_markdown(text: str | None) -> str:
+    """Strip Markdown to clean plain text (the no-parse-mode fallback)."""
+    out: list[str] = []
+    for line in (text or "").split("\n"):
+        line = re.sub(r"^\s*#{1,6}\s+", "", line)
+        line = _BOLD_RE.sub(r"\1", line)
+        line = re.sub(r"^(\s*)[-*]\s+", r"\1• ", line)
+        out.append(line)
+    return "\n".join(out)
 
 
 def _priority_emoji(urgency: int | None) -> str:

--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -34,6 +34,7 @@ from app.gmail.service import send_reply as gmail_send_reply
 from app.telegram import push as telegram_push
 from app.telegram.conversations import WAITING_FOR_TEXT, build_edit_handler
 from app.telegram.formatting import (
+    agent_text_to_md2,
     chunk_messages,
     escape_markdown_v2,
     format_analysis_entry,
@@ -41,6 +42,7 @@ from app.telegram.formatting import (
     format_email_detail,
     format_inbox_entry,
     format_unread_entry,
+    strip_markdown,
 )
 
 INBOX_DEFAULT_LIMIT = 6
@@ -767,7 +769,7 @@ async def agent_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     await _safe_delete(status)
 
     if not pending:
-        await chat.send_message(text or "Done — nothing to do.")
+        await _send_agent_reply(chat, text or "Done — nothing to do.")
         return
 
     context.user_data["agent_pending"] = pending
@@ -783,7 +785,23 @@ async def agent_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
             ]
         ]
     )
-    await chat.send_message("\n".join(lines), reply_markup=keyboard)
+    await _send_agent_reply(chat, "\n".join(lines), keyboard)
+
+
+async def _send_agent_reply(
+    chat, body: str, reply_markup: InlineKeyboardMarkup | None = None
+) -> None:
+    """Send the agent's Markdown reply rendered as MarkdownV2; plain-text on failure."""
+    try:
+        await chat.send_message(
+            agent_text_to_md2(body),
+            parse_mode=ParseMode.MARKDOWN_V2,
+            reply_markup=reply_markup,
+            link_preview_options=LinkPreviewOptions(is_disabled=True),
+        )
+    except Exception:  # noqa: BLE001 — MarkdownV2 is fiddly; never lose the reply
+        logger.exception("Agent MarkdownV2 send failed; falling back to plain text")
+        await chat.send_message(strip_markdown(body), reply_markup=reply_markup)
 
 
 @authorized_only

--- a/tests/unit/test_telegram_formatting.py
+++ b/tests/unit/test_telegram_formatting.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 
 from app.telegram.formatting import (
+    agent_text_to_md2,
     chunk_messages,
     escape_markdown_v2,
     format_analysis_entry,
@@ -11,8 +12,32 @@ from app.telegram.formatting import (
     format_notification,
     format_unread_entry,
     sender_display_name,
+    strip_markdown,
 )
 from app.telegram import formatting
+
+
+def test_agent_text_to_md2_renders_bold_and_headers():
+    md2 = agent_text_to_md2("## Urgent\nStart with **the deploy failures** now.")
+    assert md2.startswith("*Urgent*")  # header -> bold
+    assert "*the deploy failures*" in md2  # **bold** -> *bold*
+    assert "**" not in md2 and "##" not in md2  # no literal markdown left
+
+
+def test_agent_text_to_md2_escapes_reserved_chars():
+    # A bare '.' and '(' must be escaped so MarkdownV2 doesn't choke.
+    md2 = agent_text_to_md2("Reply to priya@x.com (urgent).")
+    assert "priya@x\\.com" in md2
+    assert "\\(urgent\\)" in md2
+
+
+def test_agent_text_to_md2_converts_bullets():
+    assert "• item" in agent_text_to_md2("- item")
+
+
+def test_strip_markdown_removes_syntax():
+    plain = strip_markdown("## Head\n**bold** text\n- item")
+    assert plain == "Head\nbold text\n• item"
 
 
 def test_short_time_today_shows_clock(monkeypatch):

--- a/tests/unit/test_telegram_handlers.py
+++ b/tests/unit/test_telegram_handlers.py
@@ -1254,7 +1254,7 @@ async def test_agent_command_text_only_no_pending(monkeypatch, authorized_update
     reply_context.args = ["summarize", "my", "unread"]
     await handlers.agent_command(authorized_update, reply_context)
 
-    assert "Here is your summary." in _all_reply_texts(authorized_update)
+    assert "Here is your summary" in _all_reply_texts(authorized_update)  # md2-escaped
     assert "agent_pending" not in reply_context.user_data
 
 


### PR DESCRIPTION
Closes #87

## Summary
The `/agent` reply — the bot's strongest triage feature — printed literal `**bold**` and `## headers`. Now converts standard Markdown → Telegram MarkdownV2:
- `## headers` and `**bold**` → bold; `-`/`*` bullets → `•`; everything else escaped.
- `strip_markdown` plain-text fallback on any MarkdownV2 send error, so the reply is never lost.

## Test plan
- [x] New: `agent_text_to_md2` (bold/headers/bullets/escaping) + `strip_markdown`
- [x] black + flake8 + bandit clean
- [x] pytest: 297 passed, 94.5% coverage
- [ ] Re-verify live via MCP after deploy