### PR TITLE
feat(ux): guided welcome + clean nameless-sender labels

### DIFF
--- a/app/telegram/formatting.py
+++ b/app/telegram/formatting.py
@@ -82,13 +82,36 @@ def _priority_emoji(urgency: int | None) -> str:
     return "🟢"
 
 
-def sender_display_name(raw_sender: str | None) -> str:
-    """The human-friendly sender: display name when present, else the bare address.
+# ccTLD second-level domains where the org label is the third-from-last part.
+_MULTI_PART_TLDS = {"co.uk", "co.il", "com.au", "co.jp", "org.uk", "co.nz", "com.br"}
 
-    Drops the `Name <addr>` duplication that made list rows long and auto-linked.
+
+def _sender_org(addr: str) -> str:
+    """The org label of an email's domain (e.g. swiftness@…co.il → 'swiftness').
+
+    Avoids showing a full address, which Telegram auto-links into blue noise.
+    """
+    domain = addr.rsplit("@", 1)[-1].lower()
+    labels = domain.split(".")
+    if len(labels) >= 3 and ".".join(labels[-2:]) in _MULTI_PART_TLDS:
+        return labels[-3]
+    if len(labels) >= 2:
+        return labels[-2]
+    return domain or addr
+
+
+def sender_display_name(raw_sender: str | None) -> str:
+    """The human-friendly sender: display name when present, else the domain org.
+
+    Drops the `Name <addr>` duplication and avoids a bare address that Telegram
+    would auto-link.
     """
     name, addr = parseaddr(raw_sender or "")
-    return name or addr or (raw_sender or "Unknown sender")
+    if name:
+        return name
+    if addr and "@" in addr:
+        return _sender_org(addr)
+    return addr or (raw_sender or "Unknown sender")
 
 
 def _truncate(text: str, limit: int) -> str:

--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -54,6 +54,8 @@ logger = logging.getLogger(__name__)
 
 WELCOME = (
     "Welcome to AI Email Copilot.\n\n"
+    "👉 Start with /inbox to see your priority emails — tap one to read it and act.\n"
+    "Or just ask: /agent what's urgent today?\n\n"
     "Commands:\n"
     "/unread - list unread emails\n"
     "/analyze - run AI analysis on unprocessed emails\n"

--- a/tests/unit/test_telegram_formatting.py
+++ b/tests/unit/test_telegram_formatting.py
@@ -84,8 +84,10 @@ def test_sender_display_name_prefers_display_name():
     assert sender_display_name("Qodo <no-reply@qodo.com>") == "Qodo"
 
 
-def test_sender_display_name_falls_back_to_bare_address():
-    assert sender_display_name("no-reply@qodo.com") == "no-reply@qodo.com"
+def test_sender_display_name_uses_domain_org_when_no_name():
+    # No display name → show the org label, not an auto-linkable bare address.
+    assert sender_display_name("no-reply@qodo.com") == "qodo"
+    assert sender_display_name("doNotReply@swiftness.co.il") == "swiftness"
 
 
 def test_sender_display_name_handles_none():
@@ -196,7 +198,7 @@ def test_format_inbox_entry_happy_path():
     block = format_inbox_entry(row)
     assert block.startswith("🔴")
     assert "*\\#12*" in block
-    assert "alice@example\\.com" in block
+    assert "example" in block  # nameless sender → domain org label, not bare address
     assert "Update" in block
     assert "All good\\." in block
 

--- a/tests/unit/test_telegram_handlers.py
+++ b/tests/unit/test_telegram_handlers.py
@@ -48,8 +48,7 @@ async def test_unread_replies_with_numbered_list(monkeypatch, authorized_update)
     text = _all_reply_texts(authorized_update)
     assert "*1\\.*" in text
     assert "*2\\.*" in text
-    assert "alice@example\\.com" in text
-    assert "bob@example\\.com" in text
+    assert "example" in text  # nameless senders → domain org label
 
 
 @pytest.mark.asyncio
@@ -177,11 +176,11 @@ async def test_inbox_lists_analyzed_rows(monkeypatch, authorized_update):
     monkeypatch.setattr(handlers.db, "count_analyzed_emails", lambda: 2)
     await handlers.inbox(authorized_update, None)
     text = _all_reply_texts(authorized_update)
-    assert "alice@example\\.com" in text
-    assert "bob@example\\.com" in text
-    assert "skip@example\\.com" not in text
-    assert "\\#4" in text  # row ids visible on the cards
+    assert "example" in text  # analyzed senders rendered (org label)
+    assert "skip@example\\.com" not in text  # unprocessed row excluded
+    assert "\\#4" in text  # analyzed row ids visible on the cards
     assert "\\#6" in text
+    assert "\\#5" not in text  # the unprocessed row (#5) is not shown
     assert "🔴" in text
     assert "🟢" in text
     assert "tap a button" in text.lower()  # footer points to the tap-to-open buttons


### PR DESCRIPTION
Closes #88
Closes #92

## Summary
- **#88** WELCOME leads with a triage hint: "Start with /inbox to see your priority emails — tap one to read it and act. Or just ask: /agent what's urgent today?"
- **#92** Nameless senders now show the domain org label (`swiftness`, `qodo`) instead of a bare address that Telegram auto-links into blue noise. Senders with a display name are unchanged.

## Test plan
- [x] New: `sender_display_name` org-label cases; existing list tests updated
- [x] black + flake8 + bandit clean
- [x] pytest: 297 passed, 94.5% coverage