### PR TITLE
feat(ux): bulk triage — Done all / Clear low under /inbox

### DIFF
--- a/app/database/db.py
+++ b/app/database/db.py
@@ -199,10 +199,12 @@ def get_email_by_row_id(row_id: int) -> dict | None:
 
 
 def get_recent_emails(limit: int = 50) -> list[dict]:
+    """Recent non-archived emails — Mark Done sets is_archived, clearing them here."""
     conn = get_connection()
     try:
         rows = conn.execute(
-            "SELECT * FROM emails ORDER BY created_at DESC, id DESC LIMIT ?", (limit,)
+            "SELECT * FROM emails WHERE is_archived = 0 ORDER BY created_at DESC, id DESC LIMIT ?",
+            (limit,),
         ).fetchall()
         return [dict(row) for row in rows]
     finally:
@@ -210,11 +212,11 @@ def get_recent_emails(limit: int = 50) -> list[dict]:
 
 
 def count_analyzed_emails() -> int:
-    """Total analyzed emails, for the /inbox "showing N of M" footer."""
+    """Count analyzed, non-archived emails for the /inbox "showing N of M" footer."""
     conn = get_connection()
     try:
         row = conn.execute(
-            "SELECT COUNT(*) AS n FROM emails WHERE processed_at IS NOT NULL"
+            "SELECT COUNT(*) AS n FROM emails WHERE processed_at IS NOT NULL AND is_archived = 0"
         ).fetchone()
         return int(row["n"]) if row else 0
     finally:

--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -253,8 +253,11 @@ async def analyze(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     await _send_chunks(update, blocks, "No emails to analyze.")
 
 
+INBOX_LOW_URGENCY = 5  # urgency below this is low-priority (green) — safe to bulk-clear
+
+
 def _build_inbox_keyboard(rows: list[dict]) -> InlineKeyboardMarkup | None:
-    """A tap-to-open button per analyzed email, two per row; None if empty."""
+    """Tap-to-open button per email (2/row) + a bulk-triage row; None if empty."""
     buttons = [
         InlineKeyboardButton(f"📖 #{row['id']}", callback_data=f"e:view:{row['id']}")
         for row in rows
@@ -262,27 +265,76 @@ def _build_inbox_keyboard(rows: list[dict]) -> InlineKeyboardMarkup | None:
     if not buttons:
         return None
     grid = [buttons[i : i + 2] for i in range(0, len(buttons), 2)]
+    grid.append(
+        [
+            InlineKeyboardButton("✅ Done all", callback_data="i:doneall"),
+            InlineKeyboardButton("🗄 Clear low", callback_data="i:clearlow"),
+        ]
+    )
     return InlineKeyboardMarkup(grid)
 
 
 @authorized_only
 async def inbox(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Show the most recent analyzed emails from the DB with tap-to-open buttons."""
+    """Show the most recent analyzed emails from the DB with tap-to-open + bulk triage."""
     await _typing(update)
     limit = _list_limit(context, INBOX_DEFAULT_LIMIT)
     rows = db.get_recent_emails(limit=limit)
     analyzed = [row for row in rows if row.get("processed_at")]
+    if context is not None and getattr(context, "user_data", None) is not None:
+        context.user_data["inbox_shown"] = [
+            {"id": row["id"], "urgency": row.get("urgency_score")} for row in analyzed
+        ]
     blocks = [format_inbox_entry(row) for row in analyzed]
     if blocks:
         total = db.count_analyzed_emails()
-        footer = f"Showing {len(analyzed)} of {total} · tap a button below to open"
+        footer = f"Showing {len(analyzed)} of {total} · tap to open, or bulk-triage below"
         if total > len(analyzed) and limit < LIST_MAX_LIMIT:
             footer = (
                 f"Showing {len(analyzed)} of {total} · /inbox {min(limit * 2, LIST_MAX_LIMIT)} "
-                f"for more · tap a button below to open"
+                f"for more · tap to open, or bulk-triage below"
             )
         blocks.append(escape_markdown_v2(footer))
     await _send_chunks(update, blocks, "No analyzed emails yet.", _build_inbox_keyboard(analyzed))
+
+
+@authorized_only
+async def cb_inbox_done_all(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Mark every email shown in the last /inbox done in one tap."""
+    query = update.callback_query
+    shown = (context.user_data or {}).get("inbox_shown") or []
+    ids = [s["id"] for s in shown]
+    if not ids:
+        await query.answer("Nothing to clear")
+        await update.effective_chat.send_message("Nothing to mark done — run /inbox first.")
+        return
+    for email_id in ids:
+        db.mark_email_done(email_id)
+    context.user_data.pop("inbox_shown", None)
+    await query.answer(f"Marked {len(ids)} done")
+    await update.effective_chat.send_message(
+        f"✅ Marked {len(ids)} email{'s' if len(ids) != 1 else ''} done. /inbox to refresh."
+    )
+
+
+@authorized_only
+async def cb_inbox_clear_low(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Mark only the low-priority (urgency < 5) shown emails done, keeping the rest."""
+    query = update.callback_query
+    shown = (context.user_data or {}).get("inbox_shown") or []
+    low = [s["id"] for s in shown if (s.get("urgency") or 0) < INBOX_LOW_URGENCY]
+    if not low:
+        await query.answer("No low-priority emails")
+        await update.effective_chat.send_message("No low-priority emails to clear.")
+        return
+    for email_id in low:
+        db.mark_email_done(email_id)
+    kept = [s for s in shown if (s.get("urgency") or 0) >= INBOX_LOW_URGENCY]
+    context.user_data["inbox_shown"] = kept
+    await query.answer(f"Cleared {len(low)} low")
+    await update.effective_chat.send_message(
+        f"🗄 Cleared {len(low)} low-priority · {len(kept)} kept. /inbox to refresh."
+    )
 
 
 def _build_email_detail_keyboard(row: dict) -> InlineKeyboardMarkup:
@@ -876,6 +928,8 @@ def register(application: Application) -> None:
     application.add_handler(CallbackQueryHandler(cb_email_view, pattern=r"^e:view:\d+$"))
     application.add_handler(CallbackQueryHandler(cb_email_reply, pattern=r"^e:reply:\d+$"))
     application.add_handler(CallbackQueryHandler(cb_email_done, pattern=r"^e:done:\d+$"))
+    application.add_handler(CallbackQueryHandler(cb_inbox_done_all, pattern=r"^i:doneall$"))
+    application.add_handler(CallbackQueryHandler(cb_inbox_clear_low, pattern=r"^i:clearlow$"))
     application.add_handler(CallbackQueryHandler(cb_agent_approve, pattern=r"^a:approve$"))
     application.add_handler(CallbackQueryHandler(cb_agent_cancel, pattern=r"^a:cancel$"))
 

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -164,6 +164,27 @@ def test_count_analyzed_emails_counts_only_processed():
     assert db.count_analyzed_emails() == 2
 
 
+def test_mark_email_done_removes_from_recent_and_count():
+    rid = db.insert_email(
+        {
+            "id": "arch1",
+            "thread_id": "t",
+            "sender": "a@a",
+            "subject": "s",
+            "snippet": "",
+            "date": "",
+        }
+    )
+    db.update_analysis("arch1", {"summary": "x", "category": "Work", "urgency_score": 2})
+    assert any(r["id"] == rid for r in db.get_recent_emails())
+    before = db.count_analyzed_emails()
+
+    db.mark_email_done(rid)
+
+    assert all(r["id"] != rid for r in db.get_recent_emails())  # archived → gone from inbox
+    assert db.count_analyzed_emails() == before - 1
+
+
 def _make_email(gmail_id: str = "msg_d") -> int:
     """Insert an email and return its sqlite rowid."""
     return db.insert_email(

--- a/tests/unit/test_telegram_handlers.py
+++ b/tests/unit/test_telegram_handlers.py
@@ -183,11 +183,12 @@ async def test_inbox_lists_analyzed_rows(monkeypatch, authorized_update):
     assert "\\#5" not in text  # the unprocessed row (#5) is not shown
     assert "🔴" in text
     assert "🟢" in text
-    assert "tap a button" in text.lower()  # footer points to the tap-to-open buttons
-    # tap-to-open keyboard carries one view button per analyzed email
+    assert "tap to open" in text.lower()  # footer points to the tap-to-open + bulk buttons
+    # tap-to-open keyboard carries one view button per analyzed email + bulk row
     markup = authorized_update.message.reply_text.await_args_list[-1].kwargs["reply_markup"]
     callbacks = {b.callback_data for kb_row in markup.inline_keyboard for b in kb_row}
-    assert callbacks == {"e:view:4", "e:view:6"}
+    assert {"e:view:4", "e:view:6"}.issubset(callbacks)
+    assert {"i:doneall", "i:clearlow"}.issubset(callbacks)
 
 
 @pytest.mark.asyncio
@@ -209,6 +210,74 @@ async def test_inbox_respects_count_arg(monkeypatch, authorized_update, reply_co
     reply_context.args = ["15"]
     await handlers.inbox(authorized_update, reply_context)
     assert captured["limit"] == 15
+
+
+@pytest.mark.asyncio
+async def test_inbox_stores_shown_ids_for_bulk_triage(
+    monkeypatch, authorized_update, reply_context
+):
+    rows = [
+        {
+            "id": 4,
+            "sender": "a@x.com",
+            "subject": "s",
+            "ai_summary": "x",
+            "urgency_score": 9,
+            "processed_at": "t",
+        },
+        {
+            "id": 6,
+            "sender": "b@x.com",
+            "subject": "s",
+            "ai_summary": "x",
+            "urgency_score": 3,
+            "processed_at": "t",
+        },
+    ]
+    monkeypatch.setattr(handlers.db, "get_recent_emails", lambda limit: rows)
+    monkeypatch.setattr(handlers.db, "count_analyzed_emails", lambda: 2)
+    await handlers.inbox(authorized_update, reply_context)
+    assert reply_context.user_data["inbox_shown"] == [
+        {"id": 4, "urgency": 9},
+        {"id": 6, "urgency": 3},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cb_inbox_done_all_marks_every_shown(monkeypatch, reply_context):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+    reply_context.user_data = {"inbox_shown": [{"id": 4, "urgency": 9}, {"id": 6, "urgency": 3}]}
+    done: list = []
+    monkeypatch.setattr(handlers.db, "mark_email_done", lambda eid: done.append(eid))
+    update = _make_callback_update("i:doneall")
+    await handlers.cb_inbox_done_all(update, reply_context)
+    assert done == [4, 6]
+    assert "inbox_shown" not in reply_context.user_data
+
+
+@pytest.mark.asyncio
+async def test_cb_inbox_clear_low_marks_only_low(monkeypatch, reply_context):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+    reply_context.user_data = {"inbox_shown": [{"id": 4, "urgency": 9}, {"id": 6, "urgency": 3}]}
+    done: list = []
+    monkeypatch.setattr(handlers.db, "mark_email_done", lambda eid: done.append(eid))
+    update = _make_callback_update("i:clearlow")
+    await handlers.cb_inbox_clear_low(update, reply_context)
+    assert done == [6]  # only the urgency-3 one
+    assert reply_context.user_data["inbox_shown"] == [{"id": 4, "urgency": 9}]  # high kept
+
+
+@pytest.mark.asyncio
+async def test_cb_inbox_done_all_handles_empty(monkeypatch, reply_context):
+    monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
+    monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
+    reply_context.user_data = {}
+    update = _make_callback_update("i:doneall")
+    await handlers.cb_inbox_done_all(update, reply_context)
+    sent = update.effective_chat.send_message.await_args_list[-1].args[0]
+    assert "run /inbox first" in sent.lower()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #90

## Summary
Acting was strictly one-email-at-a-time. `/inbox` now has two bulk buttons:
- **✅ Done all** — marks every shown email done in one tap.
- **🗄 Clear low** — marks only low-priority (urgency < 5) emails done, keeping the rest for action (the "clear the noise, keep what matters" move).

For Done to actually *clear* the inbox, `get_recent_emails` + `count_analyzed_emails` now **exclude `is_archived`** (which `mark_email_done` sets). Shown ids are stashed in `user_data` so the bulk callbacks act on exactly what was listed.

## Test plan
- [x] db: `mark_email_done` removes the email from `get_recent_emails` + count
- [x] handlers: Done-all marks all shown; Clear-low marks only low + keeps high; empty-state message; inbox stores shown ids; keyboard carries bulk row
- [x] black + flake8 + bandit clean; pytest 302 passed, 94.4% coverage
- [ ] Re-verify live via MCP after deploy