### PR TITLE
feat(ux): /inbox surfaces a 'N not analyzed — /analyze' banner

### DIFF
--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -285,8 +285,14 @@ async def inbox(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         context.user_data["inbox_shown"] = [
             {"id": row["id"], "urgency": row.get("urgency_score")} for row in analyzed
         ]
+    pending = len(db.get_unprocessed_emails())
     blocks = [format_inbox_entry(row) for row in analyzed]
     if blocks:
+        if pending:
+            blocks.insert(
+                0,
+                escape_markdown_v2(f"📥 {pending} new email(s) not analyzed yet — /analyze to add"),
+            )
         total = db.count_analyzed_emails()
         footer = f"Showing {len(analyzed)} of {total} · tap to open, or bulk-triage below"
         if total > len(analyzed) and limit < LIST_MAX_LIMIT:
@@ -295,7 +301,11 @@ async def inbox(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                 f"for more · tap to open, or bulk-triage below"
             )
         blocks.append(escape_markdown_v2(footer))
-    await _send_chunks(update, blocks, "No analyzed emails yet.", _build_inbox_keyboard(analyzed))
+
+    empty_msg = "No analyzed emails yet."
+    if pending:
+        empty_msg = f"No analyzed emails yet — 📥 {pending} fetched. Run /analyze to see them."
+    await _send_chunks(update, blocks, empty_msg, _build_inbox_keyboard(analyzed))
 
 
 @authorized_only

--- a/tests/unit/test_telegram_handlers.py
+++ b/tests/unit/test_telegram_handlers.py
@@ -194,8 +194,39 @@ async def test_inbox_lists_analyzed_rows(monkeypatch, authorized_update):
 @pytest.mark.asyncio
 async def test_inbox_replies_empty_when_none_analyzed(monkeypatch, authorized_update):
     monkeypatch.setattr(handlers.db, "get_recent_emails", lambda limit: [])
+    monkeypatch.setattr(handlers.db, "get_unprocessed_emails", list)
     await handlers.inbox(authorized_update, None)
     authorized_update.message.reply_text.assert_awaited_once_with("No analyzed emails yet.")
+
+
+@pytest.mark.asyncio
+async def test_inbox_shows_pending_banner_when_unprocessed(monkeypatch, authorized_update):
+    rows = [
+        {
+            "id": 4,
+            "sender": "a@x.com",
+            "subject": "s",
+            "ai_summary": "x",
+            "urgency_score": 7,
+            "processed_at": "t",
+        },
+    ]
+    monkeypatch.setattr(handlers.db, "get_recent_emails", lambda limit: rows)
+    monkeypatch.setattr(handlers.db, "count_analyzed_emails", lambda: 1)
+    monkeypatch.setattr(handlers.db, "get_unprocessed_emails", lambda: [{}, {}, {}])
+    await handlers.inbox(authorized_update, None)
+    text = _all_reply_texts(authorized_update)
+    assert "📥 3" in text  # banner counts unprocessed
+    assert "/analyze" in text
+
+
+@pytest.mark.asyncio
+async def test_inbox_empty_message_points_to_analyze_when_pending(monkeypatch, authorized_update):
+    monkeypatch.setattr(handlers.db, "get_recent_emails", lambda limit: [])
+    monkeypatch.setattr(handlers.db, "get_unprocessed_emails", lambda: [{}, {}])
+    await handlers.inbox(authorized_update, None)
+    msg = authorized_update.message.reply_text.await_args_list[-1].args[0]
+    assert "2 fetched" in msg and "/analyze" in msg
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #89

## Summary
Removes the need to *know* to run `/analyze` (the core of the `/unread`+`/analyze`+`/inbox` confusion). Low-risk **banner** approach:
- When unprocessed emails exist, `/inbox` shows a top banner: `📥 N new email(s) not analyzed yet — /analyze to add`.
- The empty-state message also points to `/analyze` when there are fetched-but-unanalyzed emails.

Pairs with the earlier WELCOME change ("Start with /inbox").

## Test plan
- [x] Banner shows with unprocessed count + `/analyze`; empty message points to `/analyze` when pending
- [x] black + flake8 + bandit clean; pytest 304 passed, 94.4% coverage
- [ ] Re-verify live via MCP after deploy