### PR TITLE
feat(ai): personalize replies in the user's voice (few-shot from Sent)

### DIFF
--- a/app/ai/prompts.py
+++ b/app/ai/prompts.py
@@ -31,7 +31,7 @@ Body: {body}
 
 TONE INSTRUCTIONS:
 {tone_instructions}
-
+{style_block}
 Rules:
 - Address every question or request in the original email.
 - Sound natural and human; do not mention that you are an AI.
@@ -41,8 +41,20 @@ Rules:
 REPLY:"""
 
 
-def build_reply_prompt(email: dict, tone: str) -> str:
-    """Render the prompt for a single tone. Raises on unknown tone."""
+def _style_block(style_samples: list[str] | None) -> str:
+    """A prompt section showing the user's own past emails to mimic their voice."""
+    if not style_samples:
+        return ""
+    examples = "\n\n---\n\n".join(style_samples)
+    return (
+        "\nMY WRITING VOICE — match my vocabulary, greeting, phrasing, and sign-off. "
+        "These are real emails I have written:\n"
+        f"{examples}\n"
+    )
+
+
+def build_reply_prompt(email: dict, tone: str, style_samples: list[str] | None = None) -> str:
+    """Render the prompt for a single tone, optionally in the user's own voice."""
     if tone not in TONE_INSTRUCTIONS:
         raise ValueError(f"Unknown tone {tone!r}; allowed: {sorted(TONE_INSTRUCTIONS)}")
     return REPLY_PROMPT.format(
@@ -51,4 +63,5 @@ def build_reply_prompt(email: dict, tone: str) -> str:
         subject=email.get("subject", "(no subject)"),
         body=email.get("body") or email.get("snippet", ""),
         tone_instructions=TONE_INSTRUCTIONS[tone],
+        style_block=_style_block(style_samples),
     )

--- a/app/ai/reply_generator.py
+++ b/app/ai/reply_generator.py
@@ -10,7 +10,7 @@ import os
 
 from anthropic import Anthropic
 
-from app.ai import MODEL
+from app.ai import MODEL, voice
 from app.ai.prompts import TONES, build_reply_prompt
 
 MAX_TOKENS = 1024
@@ -28,9 +28,9 @@ def _get_client() -> Anthropic:
     return _client
 
 
-def _generate_one(email: dict, tone: str) -> str | None:
-    """Generate a single reply or return None on API failure."""
-    prompt = build_reply_prompt(email, tone)
+def _generate_one(email: dict, tone: str, style_samples: list[str] | None = None) -> str | None:
+    """Generate a single reply (optionally in the user's voice) or None on failure."""
+    prompt = build_reply_prompt(email, tone, style_samples)
     try:
         message = _get_client().messages.create(
             model=MODEL,
@@ -62,9 +62,10 @@ def generate_replies(email: dict, tones: tuple[str, ...] = TONES) -> dict[str, s
     Tones whose API call failed are omitted from the returned dict, so
     callers can render partial results rather than blocking on a full retry.
     """
+    style_samples = voice.get_voice_samples()
     out: dict[str, str] = {}
     for tone in tones:
-        draft = _generate_one(email, tone)
+        draft = _generate_one(email, tone, style_samples)
         if draft:
             out[tone] = draft
     return out
@@ -72,4 +73,4 @@ def generate_replies(email: dict, tones: tuple[str, ...] = TONES) -> dict[str, s
 
 def regenerate_one(email: dict, tone: str) -> str | None:
     """Regenerate a single tone — used by the Telegram 'Regenerate' button."""
-    return _generate_one(email, tone)
+    return _generate_one(email, tone, voice.get_voice_samples())

--- a/app/ai/voice.py
+++ b/app/ai/voice.py
@@ -1,0 +1,85 @@
+"""Learn the user's writing voice from Sent mail, for personalized replies.
+
+The pure helpers (cleaning, selection, staleness) are unit-tested; the live Gmail
+fetch in `get_voice_samples` is `# pragma: no cover` like the rest of gmail I/O.
+"""
+
+import json
+import logging
+import re
+from datetime import datetime, timedelta
+
+from app.database import db
+from app.gmail.service import get_sent_emails
+
+logger = logging.getLogger(__name__)
+
+_PREF_SAMPLES = "voice_samples"
+_PREF_UPDATED = "voice_samples_at"
+
+MAX_SAMPLES = 5
+MIN_SAMPLE_CHARS = 80
+MAX_SAMPLE_CHARS = 800
+REFRESH_DAYS = 7
+
+# Strip the quoted-original trailer ("On <date>, X wrote:" + everything after) and
+# any ">"-prefixed quote lines, so only the user's own writing remains.
+_ON_WROTE_RE = re.compile(r"\nOn .{0,120}?wrote:.*", re.S)
+_QUOTE_LINE_RE = re.compile(r"^\s*>.*$", re.M)
+
+
+def clean_sent_body(body: str | None) -> str:
+    """Return only the user's own text from a sent email body (quotes removed)."""
+    if not body:
+        return ""
+    body = _ON_WROTE_RE.sub("", body)
+    body = _QUOTE_LINE_RE.sub("", body)
+    return body.strip()
+
+
+def select_samples(sent_emails: list[dict]) -> list[str]:
+    """Pick up to MAX_SAMPLES clean, reasonably-sized writing samples."""
+    samples: list[str] = []
+    for email in sent_emails:
+        text = clean_sent_body(email.get("body") or email.get("snippet") or "")
+        if MIN_SAMPLE_CHARS <= len(text) <= MAX_SAMPLE_CHARS:
+            samples.append(text)
+        if len(samples) >= MAX_SAMPLES:
+            break
+    return samples
+
+
+def _is_stale(updated_at: str | None) -> bool:
+    """True if the cached voice is missing or older than REFRESH_DAYS."""
+    if not updated_at:
+        return True
+    try:
+        return datetime.fromisoformat(updated_at) < datetime.now() - timedelta(days=REFRESH_DAYS)
+    except ValueError:
+        return True
+
+
+def get_voice_samples(force_refresh: bool = False) -> list[str]:  # pragma: no cover
+    """Cached writing samples, refreshed from Sent mail when stale or forced.
+
+    Returns an empty list (→ generic replies) if there's no sent history or the
+    fetch fails — personalization is best-effort, never blocking.
+    """
+    if not force_refresh and not _is_stale(db.get_preference(_PREF_UPDATED)):
+        cached = db.get_preference(_PREF_SAMPLES)
+        if cached:
+            try:
+                return json.loads(cached)
+            except json.JSONDecodeError:
+                logger.warning("Corrupt voice cache; re-learning from Sent")
+
+    try:
+        sent = get_sent_emails()
+    except Exception:  # noqa: BLE001 — personalization is optional; fall back to generic
+        logger.exception("Failed to fetch Sent mail for voice; using generic replies")
+        return []
+
+    samples = select_samples(sent)
+    db.set_preference(_PREF_SAMPLES, json.dumps(samples))
+    db.set_preference(_PREF_UPDATED, datetime.now().isoformat())
+    return samples

--- a/app/database/db.py
+++ b/app/database/db.py
@@ -223,6 +223,31 @@ def count_analyzed_emails() -> int:
         conn.close()
 
 
+def set_preference(key: str, value: str) -> None:
+    """Upsert a user preference (used to cache the learned writing voice)."""
+    conn = get_connection()
+    try:
+        conn.execute(
+            "INSERT INTO user_preferences (key, value, updated_at) VALUES (?, ?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value, "
+            "updated_at = excluded.updated_at",
+            (key, value, datetime.now().isoformat()),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def get_preference(key: str) -> str | None:
+    """Read a user preference value, or None if unset."""
+    conn = get_connection()
+    try:
+        row = conn.execute("SELECT value FROM user_preferences WHERE key = ?", (key,)).fetchone()
+        return row["value"] if row else None
+    finally:
+        conn.close()
+
+
 def get_unprocessed_emails() -> list[dict]:
     """Get emails that haven't been analyzed yet."""
     conn = get_connection()

--- a/app/gmail/service.py
+++ b/app/gmail/service.py
@@ -198,3 +198,31 @@ def get_recent_emails(max_results=50, unread_only=True):  # pragma: no cover
             continue
 
     return emails
+
+
+def get_sent_emails(max_results=15):  # pragma: no cover
+    """Fetch the user's recent sent emails, to learn their writing voice."""
+    service = get_email_service()
+    try:
+        results = (
+            service.users()
+            .messages()
+            .list(userId="me", maxResults=max_results, q="in:sent")
+            .execute()
+        )
+    except HttpError as error:
+        raise RuntimeError(f"Failed to list sent emails: {error}")
+
+    emails = []
+    for message in results.get("messages", []):
+        try:
+            msg_data = (
+                service.users()
+                .messages()
+                .get(userId="me", id=message["id"], format="full")
+                .execute()
+            )
+            emails.append(parse_email(msg_data))
+        except HttpError:
+            continue
+    return emails

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -185,6 +185,14 @@ def test_mark_email_done_removes_from_recent_and_count():
     assert db.count_analyzed_emails() == before - 1
 
 
+def test_preference_round_trips_and_upserts():
+    assert db.get_preference("voice_samples") is None
+    db.set_preference("voice_samples", "v1")
+    assert db.get_preference("voice_samples") == "v1"
+    db.set_preference("voice_samples", "v2")  # upsert, not duplicate
+    assert db.get_preference("voice_samples") == "v2"
+
+
 def _make_email(gmail_id: str = "msg_d") -> int:
     """Insert an email and return its sqlite rowid."""
     return db.insert_email(

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -35,3 +35,13 @@ def test_build_reply_prompt_handles_missing_fields():
 def test_build_reply_prompt_rejects_unknown_tone():
     with pytest.raises(ValueError, match="Unknown tone"):
         build_reply_prompt({"sender": "a"}, "shouty")
+
+
+def test_build_reply_prompt_injects_style_samples():
+    rendered = build_reply_prompt({"sender": "a"}, "brief", style_samples=["Cheers, H"])
+    assert "MY WRITING VOICE" in rendered
+    assert "Cheers, H" in rendered
+
+
+def test_build_reply_prompt_omits_style_block_without_samples():
+    assert "MY WRITING VOICE" not in build_reply_prompt({"sender": "a"}, "brief")

--- a/tests/unit/test_reply_generator.py
+++ b/tests/unit/test_reply_generator.py
@@ -34,12 +34,32 @@ def _stub_client_per_tone(by_tone: dict[str, str]) -> MagicMock:
     return client
 
 
+@pytest.fixture(autouse=True)
+def _no_voice(monkeypatch):
+    """Default: no learned voice, so tests don't hit live Gmail."""
+    monkeypatch.setattr(reply_generator.voice, "get_voice_samples", lambda *a, **k: [])
+
+
 @pytest.fixture
 def patch_client(monkeypatch):
     def _apply(client):
         monkeypatch.setattr(reply_generator, "_get_client", lambda: client)
 
     return _apply
+
+
+def test_generate_replies_injects_voice_samples_into_prompt(patch_client, monkeypatch):
+    monkeypatch.setattr(
+        reply_generator.voice, "get_voice_samples", lambda *a, **k: ["Cheers, Hisham"]
+    )
+    client = _stub_client("draft")
+    patch_client(client)
+
+    reply_generator.generate_replies({"sender": "a", "subject": "s", "body": "b"})
+
+    prompt = client.messages.create.call_args.kwargs["messages"][0]["content"]
+    assert "Cheers, Hisham" in prompt  # the user's voice sample reached the prompt
+    assert "MY WRITING VOICE" in prompt
 
 
 def test_generate_replies_returns_dict_keyed_by_tone(patch_client):

--- a/tests/unit/test_voice.py
+++ b/tests/unit/test_voice.py
@@ -1,0 +1,44 @@
+"""Unit tests for app/ai/voice.py pure helpers (no live Gmail)."""
+
+from datetime import datetime, timedelta
+
+from app.ai import voice
+
+
+def test_clean_sent_body_strips_quoted_reply_trailer():
+    body = (
+        "Sounds good, see you then.\n\n"
+        "On Mon, 10 May 2026, Alice wrote:\n> the original\n> more quote"
+    )
+    assert voice.clean_sent_body(body) == "Sounds good, see you then."
+
+
+def test_clean_sent_body_strips_quote_lines():
+    body = "Yes please.\n> quoted line\nThanks"
+    cleaned = voice.clean_sent_body(body)
+    assert ">" not in cleaned
+    assert "Yes please." in cleaned and "Thanks" in cleaned
+
+
+def test_clean_sent_body_handles_none():
+    assert voice.clean_sent_body(None) == ""
+
+
+def test_select_samples_filters_by_length_and_caps_count():
+    short = {"body": "too short"}
+    good = {"body": "x" * 200}
+    huge = {"body": "y" * 5000}
+    emails = [short, good, huge] + [{"body": "z" * 150} for _ in range(10)]
+    samples = voice.select_samples(emails)
+    assert len(samples) <= voice.MAX_SAMPLES
+    assert all(voice.MIN_SAMPLE_CHARS <= len(s) <= voice.MAX_SAMPLE_CHARS for s in samples)
+    assert "too short" not in samples
+
+
+def test_is_stale_logic():
+    assert voice._is_stale(None) is True
+    assert voice._is_stale("not-a-date") is True
+    fresh = datetime.now().isoformat()
+    assert voice._is_stale(fresh) is False
+    old = (datetime.now() - timedelta(days=voice.REFRESH_DAYS + 1)).isoformat()
+    assert voice._is_stale(old) is True


### PR DESCRIPTION
Closes #98 (Phase 1)

## Summary
Replies were fully generic. They now learn the user's writing voice from their **Sent mail** and write in it.

- `gmail.get_sent_emails()` — fetch sent mail (`q="in:sent"`, existing read scope).
- `app/ai/voice.py` — strip quoted reply text, select ~5 length-filtered samples, cache in `user_preferences` with a 7-day staleness refresh. Pure helpers (clean/select/staleness) are unit-tested; live fetch is `# pragma: no cover`.
- `db.set_preference`/`get_preference`.
- `build_reply_prompt(email, tone, style_samples)` injects a **"MY WRITING VOICE"** block; `reply_generator` passes the cached samples.
- **Graceful fallback** to generic when there's no Sent history or the fetch fails — never blocks.

## Test plan
- [x] voice: quote-stripping, sample selection (length-filter + cap), staleness
- [x] db: preference round-trip + upsert
- [x] prompts: style block injected/omitted
- [x] reply_generator: voice samples reach the prompt; autouse mock keeps tests off live Gmail
- [x] black + flake8 + bandit clean; pytest 313 passed, 94.6% coverage
- [ ] Re-verify live via MCP after deploy

## Phase 2 (follow-up, supersedes #91)
Collapse 3 tones → one "your voice" draft (faster) + ✏ shorter / ✏ warmer nudges; optional `/learn`.