### PR TITLE
feat(ux): one voice draft + Shorter/Warmer nudges (faster /reply)

### DIFF
--- a/app/ai/prompts.py
+++ b/app/ai/prompts.py
@@ -19,6 +19,16 @@ TONE_INSTRUCTIONS: dict[str, str] = {
         "Under three sentences. Direct, no filler. Skip the salutation if it "
         "would push the message over three sentences."
     ),
+    "voice": (
+        "Reply naturally in my own voice and typical length — match the greeting, "
+        "phrasing, and sign-off from my writing examples below."
+    ),
+}
+
+# Nudges that tweak a generated draft on demand (the Shorter/Warmer buttons).
+REPLY_MODIFIERS: dict[str, str] = {
+    "shorter": "Make this reply noticeably shorter and more direct.",
+    "warmer": "Make this reply warmer, friendlier, and more personable.",
 }
 
 
@@ -53,15 +63,25 @@ def _style_block(style_samples: list[str] | None) -> str:
     )
 
 
-def build_reply_prompt(email: dict, tone: str, style_samples: list[str] | None = None) -> str:
-    """Render the prompt for a single tone, optionally in the user's own voice."""
+def build_reply_prompt(
+    email: dict,
+    tone: str,
+    style_samples: list[str] | None = None,
+    modifier: str | None = None,
+) -> str:
+    """Render the prompt for a single tone, optionally in the user's voice + a nudge."""
     if tone not in TONE_INSTRUCTIONS:
         raise ValueError(f"Unknown tone {tone!r}; allowed: {sorted(TONE_INSTRUCTIONS)}")
+    instructions = TONE_INSTRUCTIONS[tone]
+    if modifier:
+        if modifier not in REPLY_MODIFIERS:
+            raise ValueError(f"Unknown modifier {modifier!r}; allowed: {sorted(REPLY_MODIFIERS)}")
+        instructions = f"{instructions} {REPLY_MODIFIERS[modifier]}"
     return REPLY_PROMPT.format(
         tone=tone,
         sender=email.get("sender", "Unknown"),
         subject=email.get("subject", "(no subject)"),
         body=email.get("body") or email.get("snippet", ""),
-        tone_instructions=TONE_INSTRUCTIONS[tone],
+        tone_instructions=instructions,
         style_block=_style_block(style_samples),
     )

--- a/app/ai/reply_generator.py
+++ b/app/ai/reply_generator.py
@@ -28,9 +28,14 @@ def _get_client() -> Anthropic:
     return _client
 
 
-def _generate_one(email: dict, tone: str, style_samples: list[str] | None = None) -> str | None:
-    """Generate a single reply (optionally in the user's voice) or None on failure."""
-    prompt = build_reply_prompt(email, tone, style_samples)
+def _generate_one(
+    email: dict,
+    tone: str,
+    style_samples: list[str] | None = None,
+    modifier: str | None = None,
+) -> str | None:
+    """Generate a single reply (optionally in the user's voice + a nudge) or None."""
+    prompt = build_reply_prompt(email, tone, style_samples, modifier)
     try:
         message = _get_client().messages.create(
             model=MODEL,
@@ -74,3 +79,8 @@ def generate_replies(email: dict, tones: tuple[str, ...] = TONES) -> dict[str, s
 def regenerate_one(email: dict, tone: str) -> str | None:
     """Regenerate a single tone — used by the Telegram 'Regenerate' button."""
     return _generate_one(email, tone, voice.get_voice_samples())
+
+
+def generate_voice_reply(email: dict, modifier: str | None = None) -> str | None:
+    """Generate one reply in the user's voice (the default /reply draft + nudges)."""
+    return _generate_one(email, "voice", voice.get_voice_samples(), modifier)

--- a/app/telegram/formatting.py
+++ b/app/telegram/formatting.py
@@ -274,6 +274,14 @@ def format_drafts_message(email: dict, drafts: list[dict]) -> str:
     return "".join(sections) if len(sections) == 1 else "\n".join(sections)
 
 
+def format_single_draft(email: dict, draft_text: str) -> str:
+    """Render one draft (in the user's voice) as a MarkdownV2 message."""
+    sender = escape_markdown_v2(sender_display_name(email.get("sender")))
+    subject = escape_markdown_v2(email.get("subject") or "(no subject)")
+    body = escape_markdown_v2(draft_text or "")
+    return f"✍️ *Draft reply to* {sender}\n*Re:* {subject}\n\n{body}"
+
+
 def format_notification(row: dict) -> str:
     """MarkdownV2 push-notification block: sender, subject, category, urgency, summary."""
     sender = escape_markdown_v2(row.get("sender") or "Unknown sender")

--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -25,7 +25,7 @@ from telegram.ext import (
 from app.ai import agent
 from app.ai.analyzer import analyze_email
 from app.ai.meeting_detector import maybe_detect_meeting
-from app.ai.reply_generator import generate_replies, regenerate_one
+from app.ai.reply_generator import generate_voice_reply
 from app.calendar import scheduler
 from app.database import db
 from app.gmail.service import get_recent_emails as gmail_fetch_recent
@@ -38,9 +38,9 @@ from app.telegram.formatting import (
     chunk_messages,
     escape_markdown_v2,
     format_analysis_entry,
-    format_drafts_message,
     format_email_detail,
     format_inbox_entry,
+    format_single_draft,
     format_unread_entry,
     strip_markdown,
 )
@@ -403,34 +403,37 @@ async def cb_email_view(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     await _send_email_detail(update.effective_chat, row)
 
 
-_REPLY_TONES = ("professional", "friendly", "brief")
-_TONE_GLYPH = {"professional": "🎩", "friendly": "😊", "brief": "⚡"}
-
-
-def _build_reply_keyboard(drafts: list[dict], email_id: int) -> InlineKeyboardMarkup:
-    """Build the Approve/Edit/Regenerate per tone + Skip All keyboard."""
-    rows = []
-    by_tone = {d["tone"]: d for d in drafts}
-    for tone in _REPLY_TONES:
-        draft = by_tone.get(tone)
-        if not draft:
-            continue
-        glyph = _TONE_GLYPH[tone]
-        rows.append(
+def _build_reply_keyboard(draft_id: int, email_id: int) -> InlineKeyboardMarkup:
+    """Single-draft actions: Send / Shorter / Warmer / Edit / Skip."""
+    return InlineKeyboardMarkup(
+        [
             [
-                InlineKeyboardButton(
-                    f"{glyph} ✅ Approve", callback_data=f"r:approve:{draft['id']}"
-                ),
-                InlineKeyboardButton(f"{glyph} ✏ Edit", callback_data=f"r:edit:{draft['id']}"),
-                InlineKeyboardButton(f"{glyph} 🔄 Regen", callback_data=f"r:regen:{draft['id']}"),
-            ]
-        )
-    rows.append([InlineKeyboardButton("⏭ Skip all", callback_data=f"r:skip:{email_id}")])
-    return InlineKeyboardMarkup(rows)
+                InlineKeyboardButton("✅ Send", callback_data=f"r:approve:{draft_id}"),
+                InlineKeyboardButton("✏ Shorter", callback_data=f"r:shorter:{draft_id}"),
+                InlineKeyboardButton("✏ Warmer", callback_data=f"r:warmer:{draft_id}"),
+            ],
+            [
+                InlineKeyboardButton("✏ Edit", callback_data=f"r:edit:{draft_id}"),
+                InlineKeyboardButton("⏭ Skip", callback_data=f"r:skip:{email_id}"),
+            ],
+        ]
+    )
+
+
+async def _send_draft_message(chat, email: dict, draft: dict) -> None:
+    """Send/replace the single-draft message with its action keyboard."""
+    keyboard = _build_reply_keyboard(draft["id"], email["id"])
+    body = format_single_draft(email, draft["draft_text"])
+    for chunk in chunk_messages([body]):
+        try:
+            await chat.send_message(chunk, parse_mode=ParseMode.MARKDOWN_V2, reply_markup=keyboard)
+        except Exception:  # noqa: BLE001 — MarkdownV2 is fiddly; never lose the draft
+            logger.exception("MarkdownV2 send failed; falling back to plain text")
+            await chat.send_message(chunk, reply_markup=keyboard)
 
 
 async def _run_reply_flow(update: Update, email_id: int) -> None:
-    """Generate 3 drafts for email_id, persist, and post with action keyboard.
+    """Generate ONE reply in the user's voice, persist it, and post with actions.
 
     Uses `effective_chat.send_message` so it works identically from `/reply <id>`
     and from the notification's "Generate Reply" button (PTB freezes Update
@@ -453,33 +456,15 @@ async def _run_reply_flow(update: Update, email_id: int) -> None:
         return
 
     await _typing(update)
-    await chat.send_message("✍️ Drafting 3 replies… this can take up to a minute.")
+    await chat.send_message("✍️ Drafting a reply in your voice…")
     await _typing(update)
-    replies = await asyncio.to_thread(generate_replies, email)
-    if not replies:
-        await chat.send_message("Couldn't draft replies — try again in a moment.")
+    text = await asyncio.to_thread(generate_voice_reply, email)
+    if not text:
+        await chat.send_message("Couldn't draft a reply — try again in a moment.")
         return
 
-    drafts: list[dict] = []
-    for tone, text in replies.items():
-        draft_id = db.insert_draft_reply(email_id, tone, text)
-        drafts.append(db.get_draft_by_id(draft_id))
-
-    body = format_drafts_message(email, drafts)
-    keyboard = _build_reply_keyboard(drafts, email_id)
-    for chunk in chunk_messages([body]):
-        try:
-            await chat.send_message(
-                chunk,
-                parse_mode=ParseMode.MARKDOWN_V2,
-                reply_markup=keyboard,
-            )
-        except Exception:  # noqa: BLE001
-            # MarkdownV2 escaping is fiddly; fall back to plain text so the
-            # user always sees the drafts even if a stray reserved char slips
-            # through escape_markdown_v2.
-            logger.exception("MarkdownV2 send failed; falling back to plain text")
-            await chat.send_message(chunk, reply_markup=keyboard)
+    draft_id = db.insert_draft_reply(email_id, "voice", text)
+    await _send_draft_message(chat, email, db.get_draft_by_id(draft_id))
 
 
 @authorized_only
@@ -606,14 +591,14 @@ async def cb_skip(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 @authorized_only
-async def cb_regenerate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Regenerate one tone — replace draft_text in place; leave others untouched."""
+async def cb_reply_nudge(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Shorter/Warmer — regenerate the draft in the user's voice with that nudge."""
     query = update.callback_query
-    await query.answer("Regenerating…")
+    await query.answer("Reworking…")
     parsed = _parse_callback(query.data or "")
-    if parsed is None or parsed[0] != "regen":
+    if parsed is None or parsed[0] not in ("shorter", "warmer"):
         return
-    _, draft_id = parsed
+    modifier, draft_id = parsed
     draft = db.get_draft_by_id(draft_id)
     if draft is None:
         await update.effective_chat.send_message("That draft no longer exists.")
@@ -624,14 +609,12 @@ async def cb_regenerate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         return
 
     await _typing(update)
-    new_text = await asyncio.to_thread(regenerate_one, email, draft["tone"])
+    new_text = await asyncio.to_thread(generate_voice_reply, email, modifier)
     if not new_text:
-        await update.effective_chat.send_message(f"Regenerate failed for {draft['tone']}.")
+        await update.effective_chat.send_message(f"Couldn't make it {modifier} — try again.")
         return
     db.update_draft_status(draft_id, "pending", draft_text=new_text)
-    await update.effective_chat.send_message(
-        f"🔄 New {draft['tone']} draft saved — tap Approve when ready."
-    )
+    await _send_draft_message(update.effective_chat, email, db.get_draft_by_id(draft_id))
 
 
 @authorized_only
@@ -930,7 +913,9 @@ def register(application: Application) -> None:
     application.add_handler(build_edit_handler(cb_edit_start, cb_edit_save))
     application.add_handler(CallbackQueryHandler(cb_approve, pattern=r"^r:approve:\d+$"))
     application.add_handler(CallbackQueryHandler(cb_skip, pattern=r"^r:skip:\d+$"))
-    application.add_handler(CallbackQueryHandler(cb_regenerate, pattern=r"^r:regen:\d+$"))
+    application.add_handler(
+        CallbackQueryHandler(cb_reply_nudge, pattern=r"^r:(shorter|warmer):\d+$")
+    )
     application.add_handler(CallbackQueryHandler(cb_notify_reply, pattern=r"^n:reply:\d+$"))
     application.add_handler(CallbackQueryHandler(cb_notify_done, pattern=r"^n:done:\d+$"))
     application.add_handler(CallbackQueryHandler(cb_schedule_create, pattern=r"^s:create:\d+$"))

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -5,9 +5,11 @@ import pytest
 from app.ai.prompts import TONE_INSTRUCTIONS, TONES, build_reply_prompt
 
 
-def test_three_tones_present():
+def test_tone_presets_and_voice_present():
     assert set(TONES) == {"professional", "friendly", "brief"}
-    assert set(TONE_INSTRUCTIONS) == set(TONES)
+    # TONE_INSTRUCTIONS also carries the single-draft "voice" register.
+    assert set(TONES).issubset(set(TONE_INSTRUCTIONS))
+    assert "voice" in TONE_INSTRUCTIONS
 
 
 def test_build_reply_prompt_includes_email_fields():

--- a/tests/unit/test_telegram_handlers.py
+++ b/tests/unit/test_telegram_handlers.py
@@ -485,40 +485,34 @@ async def test_reply_command_rejects_unanalyzed_email(
 
 
 @pytest.mark.asyncio
-async def test_reply_command_persists_drafts_and_renders(
+async def test_reply_command_persists_one_voice_draft_and_renders(
     monkeypatch, authorized_update, reply_context
 ):
     row = _analyzed_email_row()
     monkeypatch.setattr(handlers.db, "get_email_by_row_id", lambda _: row)
     monkeypatch.setattr(
-        handlers,
-        "generate_replies",
-        lambda email: {"professional": "Pro reply", "friendly": "Hey", "brief": "Yes"},
+        handlers, "generate_voice_reply", lambda email, modifier=None: "In my voice."
     )
 
     inserted: list[tuple] = []
 
     def fake_insert(email_id, tone, text):
         inserted.append((email_id, tone, text))
-        return len(inserted)
+        return 1
 
     monkeypatch.setattr(handlers.db, "insert_draft_reply", fake_insert)
     monkeypatch.setattr(
         handlers.db,
         "get_draft_by_id",
-        lambda did: {
-            "id": did,
-            "tone": inserted[did - 1][1],
-            "draft_text": inserted[did - 1][2],
-        },
+        lambda did: {"id": did, "tone": "voice", "draft_text": "In my voice."},
     )
     reply_context.args = ["5"]
     await handlers.reply_command(authorized_update, reply_context)
 
-    assert {t for _, t, _ in inserted} == {"professional", "friendly", "brief"}
+    assert inserted == [(5, "voice", "In my voice.")]  # one draft, voice tone
     text = _all_reply_texts(authorized_update)
     assert "Drafting" in text
-    assert "Professional" in text or "🎩" in text
+    assert "In my voice" in text  # the draft body is rendered
 
 
 @pytest.mark.asyncio
@@ -526,28 +520,26 @@ async def test_reply_command_handles_empty_generation(
     monkeypatch, authorized_update, reply_context
 ):
     monkeypatch.setattr(handlers.db, "get_email_by_row_id", lambda _: _analyzed_email_row())
-    monkeypatch.setattr(handlers, "generate_replies", lambda _: {})
+    monkeypatch.setattr(handlers, "generate_voice_reply", lambda *a, **k: None)
     reply_context.args = ["5"]
     await handlers.reply_command(authorized_update, reply_context)
-    assert "Couldn't draft replies" in _all_reply_texts(authorized_update)
+    assert "Couldn't draft a reply" in _all_reply_texts(authorized_update)
 
 
 @pytest.mark.asyncio
-async def test_reply_drafting_message_has_realistic_eta(monkeypatch, authorized_update):
-    """The progress message must not under-promise the ~1 min generation time."""
+async def test_reply_drafting_message_mentions_voice(monkeypatch, authorized_update):
     monkeypatch.setattr(handlers.db, "get_email_by_row_id", lambda _: _analyzed_email_row())
-    monkeypatch.setattr(handlers, "generate_replies", lambda _: {"brief": "Yes"})
+    monkeypatch.setattr(handlers, "generate_voice_reply", lambda *a, **k: "Yes")
     monkeypatch.setattr(handlers.db, "insert_draft_reply", lambda *_: 1)
     monkeypatch.setattr(
         handlers.db,
         "get_draft_by_id",
-        lambda did: {"id": did, "tone": "brief", "draft_text": "Yes"},
+        lambda did: {"id": did, "tone": "voice", "draft_text": "Yes"},
     )
     await handlers._run_reply_flow(authorized_update, 5)
     text = _all_reply_texts(authorized_update)
     assert "Drafting" in text
-    assert "~10s" not in text
-    assert "minute" in text
+    assert "voice" in text.lower()  # one fast voice draft, not "3 replies… a minute"
 
 
 @pytest.mark.asyncio
@@ -559,12 +551,12 @@ async def test_reply_command_skips_no_reply_sender(monkeypatch, authorized_updat
 
     gen_called = False
 
-    def fake_generate(_):
+    def fake_generate(*a, **k):
         nonlocal gen_called
         gen_called = True
-        return {"brief": "Yes"}
+        return "Yes"
 
-    monkeypatch.setattr(handlers, "generate_replies", fake_generate)
+    monkeypatch.setattr(handlers, "generate_voice_reply", fake_generate)
     reply_context.args = ["5"]
     await handlers.reply_command(authorized_update, reply_context)
 
@@ -744,40 +736,40 @@ async def test_cb_skip_marks_all_pending_drafts_skipped(monkeypatch, reply_conte
 
 
 @pytest.mark.asyncio
-async def test_cb_regenerate_replaces_only_chosen_tone(monkeypatch, reply_context):
+async def test_cb_reply_nudge_reworks_draft_in_voice(monkeypatch, reply_context):
     monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
     monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
-    monkeypatch.setattr(
-        handlers.db,
-        "get_draft_by_id",
-        lambda _: {
-            "id": 9,
-            "email_id": 5,
-            "tone": "brief",
-            "draft_text": "old",
-            "status": "pending",
-        },
-    )
+    draft = {"id": 9, "email_id": 5, "tone": "voice", "draft_text": "old", "status": "pending"}
+    monkeypatch.setattr(handlers.db, "get_draft_by_id", lambda _: draft)
     monkeypatch.setattr(handlers.db, "get_email_by_row_id", lambda _: _analyzed_email_row())
-    monkeypatch.setattr(handlers, "regenerate_one", lambda email, tone: "fresh take")
 
+    gen_args: list = []
+
+    def fake_gen(email, modifier=None):
+        gen_args.append(modifier)
+        return "shorter take"
+
+    monkeypatch.setattr(handlers, "generate_voice_reply", fake_gen)
     updates: list[tuple] = []
-    monkeypatch.setattr(
-        handlers.db,
-        "update_draft_status",
-        lambda did, status, **kw: updates.append((did, status, kw)),
-    )
 
-    update = _make_callback_update("r:regen:9")
-    await handlers.cb_regenerate(update, reply_context)
+    def fake_update(did, status, **kw):
+        updates.append((did, status, kw))
+        if "draft_text" in kw:
+            draft["draft_text"] = kw["draft_text"]  # reflect the persisted update
 
-    assert updates == [(9, "pending", {"draft_text": "fresh take"})]
-    msg = update.effective_chat.send_message.await_args_list[-1].args[0]
-    assert "brief" in msg
+    monkeypatch.setattr(handlers.db, "update_draft_status", fake_update)
+
+    update = _make_callback_update("r:shorter:9")
+    await handlers.cb_reply_nudge(update, reply_context)
+
+    assert gen_args == ["shorter"]  # the modifier reached the generator
+    assert updates == [(9, "pending", {"draft_text": "shorter take"})]
+    sent = " ".join(c.args[0] for c in update.effective_chat.send_message.await_args_list if c.args)
+    assert "shorter take" in sent  # re-rendered draft
 
 
 @pytest.mark.asyncio
-async def test_cb_regenerate_reports_failure(monkeypatch, reply_context):
+async def test_cb_reply_nudge_reports_failure(monkeypatch, reply_context):
     monkeypatch.setenv("TELEGRAM_AUTHORIZED_CHAT_ID", "42")
     monkeypatch.setattr(handlers.db, "get_or_create_telegram_user", lambda _: {})
     monkeypatch.setattr(
@@ -786,17 +778,17 @@ async def test_cb_regenerate_reports_failure(monkeypatch, reply_context):
         lambda _: {
             "id": 9,
             "email_id": 5,
-            "tone": "brief",
+            "tone": "voice",
             "draft_text": "old",
             "status": "pending",
         },
     )
     monkeypatch.setattr(handlers.db, "get_email_by_row_id", lambda _: _analyzed_email_row())
-    monkeypatch.setattr(handlers, "regenerate_one", lambda *_: None)
-    update = _make_callback_update("r:regen:9")
-    await handlers.cb_regenerate(update, reply_context)
+    monkeypatch.setattr(handlers, "generate_voice_reply", lambda *a, **k: None)
+    update = _make_callback_update("r:warmer:9")
+    await handlers.cb_reply_nudge(update, reply_context)
     msg = update.effective_chat.send_message.await_args_list[-1].args[0]
-    assert "Regenerate failed" in msg
+    assert "warmer" in msg.lower()
 
 
 @pytest.mark.asyncio
@@ -1005,16 +997,12 @@ async def test_run_reply_flow_falls_back_to_plain_text_on_markdown_error(
         "get_email_by_row_id",
         lambda _: _analyzed_email_row(),
     )
-    monkeypatch.setattr(
-        handlers,
-        "generate_replies",
-        lambda _: {"professional": "P", "friendly": "F", "brief": "B"},
-    )
+    monkeypatch.setattr(handlers, "generate_voice_reply", lambda *a, **k: "P")
     monkeypatch.setattr(handlers.db, "insert_draft_reply", lambda *_: 1)
     monkeypatch.setattr(
         handlers.db,
         "get_draft_by_id",
-        lambda did: {"id": did, "tone": "professional", "draft_text": "P"},
+        lambda did: {"id": did, "tone": "voice", "draft_text": "P"},
     )
 
     calls = []


### PR DESCRIPTION
Closes #91 (and #98 Phase 2)

## Summary
`/reply` now generates **one** reply in the user's voice (one Claude call ≈ faster, vs three generic tones ≈ a minute), shown with **[✅ Send] [✏ Shorter] [✏ Warmer] [✏ Edit] [⏭ Skip]**. Shorter/Warmer regenerate the draft *in voice* with a nudge modifier and re-render it in place.

- `prompts`: a `"voice"` tone + `REPLY_MODIFIERS` (shorter/warmer)
- `reply_generator.generate_voice_reply(email, modifier)`
- `formatting.format_single_draft`; `handlers`: single-draft flow + `cb_reply_nudge` (replaces the 3-tone keyboard and `cb_regenerate`)

## Test plan
- [x] one voice draft persisted + rendered; empty-gen + no-reply paths; nudge reworks in-voice with the right modifier; failure message; markdown fallback
- [x] black + flake8 + bandit clean; pytest 313 passed, 94% coverage
- [ ] Re-verify live via MCP after deploy