### PR TITLE
fix(ux): edit re-shows draft for review instead of auto-sending

### DIFF
--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -551,9 +551,7 @@ async def cb_edit_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
         await update.effective_chat.send_message("That draft no longer exists.")
         return -1
     context.user_data["editing_draft_id"] = draft_id
-    await update.effective_chat.send_message(
-        f"Send the revised {draft['tone']} reply (or /cancel to abort)."
-    )
+    await update.effective_chat.send_message("Type your revised reply (or /cancel to abort).")
     return WAITING_FOR_TEXT
 
 
@@ -567,10 +565,16 @@ async def cb_edit_save(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     if not new_text:
         await update.message.reply_text("Empty message — edit cancelled.")
         return -1
+    # Don't send: update the draft and re-show it with the action keyboard so the
+    # user reviews and explicitly taps Send (editing shouldn't fire off email).
     db.update_draft_status(draft_id, "edited", draft_text=new_text)
-    await _typing(update)
-    await update.message.reply_text("✍️ Sending edited reply…")
-    await _send_draft(update, context, draft_id, source="edit")
+    draft = db.get_draft_by_id(draft_id)
+    email = db.get_email_by_row_id(draft["email_id"]) if draft else None
+    if email is None:
+        await update.message.reply_text("Original email not found.")
+        return -1
+    await update.message.reply_text("✏ Draft updated — review and tap Send.")
+    await _send_draft_message(update.effective_chat, email, draft)
     return -1
 
 

--- a/tests/unit/test_telegram_handlers.py
+++ b/tests/unit/test_telegram_handlers.py
@@ -808,38 +808,44 @@ async def test_cb_edit_start_stashes_draft_id(monkeypatch, reply_context):
 
 
 @pytest.mark.asyncio
-async def test_cb_edit_save_overwrites_then_sends(monkeypatch, authorized_update, reply_context):
+async def test_cb_edit_save_updates_draft_for_review_not_send(
+    monkeypatch, authorized_update, reply_context
+):
+    """Editing must NOT send — it updates the draft and re-shows it for review."""
     reply_context.user_data["editing_draft_id"] = 7
     authorized_update.message.text = "  My revised draft.  "
     authorized_update.effective_chat.send_message = AsyncMock()
 
-    monkeypatch.setattr(
-        handlers.db,
-        "get_draft_by_id",
-        lambda _: {
-            "id": 7,
-            "email_id": 5,
-            "tone": "friendly",
-            "draft_text": "My revised draft.",
-            "status": "edited",
-        },
-    )
-    monkeypatch.setattr(handlers.db, "get_email_by_row_id", lambda _: _analyzed_email_row())
-    monkeypatch.setattr(handlers, "gmail_send_reply", lambda *_: "new-id")
-
+    draft = {"id": 7, "email_id": 5, "tone": "voice", "draft_text": "old", "status": "pending"}
     status_calls: list[tuple] = []
-    monkeypatch.setattr(
-        handlers.db,
-        "update_draft_status",
-        lambda did, status, **kw: status_calls.append((did, status, kw)),
-    )
+
+    def fake_update(did, status, **kw):
+        status_calls.append((did, status, kw))
+        if "draft_text" in kw:
+            draft["draft_text"] = kw["draft_text"]
+
+    monkeypatch.setattr(handlers.db, "get_draft_by_id", lambda _: draft)
+    monkeypatch.setattr(handlers.db, "get_email_by_row_id", lambda _: _analyzed_email_row())
+    monkeypatch.setattr(handlers.db, "update_draft_status", fake_update)
+
+    sent = False
+
+    def boom(*_):
+        nonlocal sent
+        sent = True
+        return "id"
+
+    monkeypatch.setattr(handlers, "gmail_send_reply", boom)
 
     state = await handlers.cb_edit_save(authorized_update, reply_context)
 
     assert state == -1
-    # First call: 'edited' with the new text. Second call: 'sent' inside _send_draft.
-    assert status_calls[0] == (7, "edited", {"draft_text": "My revised draft."})
-    assert status_calls[1] == (7, "sent", {"mark_sent": True})
+    assert status_calls == [(7, "edited", {"draft_text": "My revised draft."})]  # text saved
+    assert sent is False  # NOT sent — re-rendered for review instead
+    rendered = " ".join(
+        c.args[0] for c in authorized_update.effective_chat.send_message.await_args_list if c.args
+    )
+    assert "My revised draft" in rendered  # the revised draft is shown for review
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #101

## Summary
Tapping **✏ Edit** then typing a revision **sent the email immediately** — a footgun with no review. Now `cb_edit_save` updates the draft and **re-renders it with the Send/Shorter/Warmer/Edit/Skip keyboard**, so the user explicitly taps Send. Reworded the prompt to *"Type your revised reply (or /cancel)"*.

## Test plan
- [x] Edit save updates the draft text, does NOT send, re-shows the revised draft for review
- [x] black + flake8 + bandit clean; pytest 313 passed
