### PR TITLE
feat(ux): tap-to-open buttons for #ids in /agent replies

### DIFF
--- a/app/telegram/handlers.py
+++ b/app/telegram/handlers.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import os
+import re
 from functools import wraps
 
 from telegram import (
@@ -820,7 +821,7 @@ async def agent_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     await _safe_delete(status)
 
     if not pending:
-        await _send_agent_reply(chat, text or "Done — nothing to do.")
+        await _send_agent_reply(chat, text or "Done — nothing to do.", _email_refs_keyboard(text))
         return
 
     context.user_data["agent_pending"] = pending
@@ -837,6 +838,26 @@ async def agent_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         ]
     )
     await _send_agent_reply(chat, "\n".join(lines), keyboard)
+
+
+_EMAIL_REF_RE = re.compile(r"#(\d+)")
+
+
+def _email_refs_keyboard(text: str | None) -> InlineKeyboardMarkup | None:
+    """Tap-to-open buttons for any #<id> emails the agent referenced (max 6)."""
+    if not text:
+        return None
+    seen: list[str] = []
+    for match in _EMAIL_REF_RE.finditer(text):
+        if match.group(1) not in seen:
+            seen.append(match.group(1))
+        if len(seen) >= 6:
+            break
+    if not seen:
+        return None
+    buttons = [InlineKeyboardButton(f"📖 #{i}", callback_data=f"e:view:{i}") for i in seen]
+    grid = [buttons[i : i + 2] for i in range(0, len(buttons), 2)]
+    return InlineKeyboardMarkup(grid)
 
 
 async def _send_agent_reply(

--- a/tests/unit/test_telegram_handlers.py
+++ b/tests/unit/test_telegram_handlers.py
@@ -1351,6 +1351,34 @@ async def test_agent_command_text_only_no_pending(monkeypatch, authorized_update
     assert "agent_pending" not in reply_context.user_data
 
 
+def test_email_refs_keyboard_extracts_deduped_ids():
+    kb = handlers._email_refs_keyboard("Start with #15359, then #15356 and #15359 again.")
+    cbs = [b.callback_data for row in kb.inline_keyboard for b in row]
+    assert cbs == ["e:view:15359", "e:view:15356"]  # deduped, in order
+
+
+def test_email_refs_keyboard_none_without_ids():
+    assert handlers._email_refs_keyboard("nothing to open here") is None
+    assert handlers._email_refs_keyboard(None) is None
+
+
+@pytest.mark.asyncio
+async def test_agent_reply_attaches_email_ref_buttons(
+    monkeypatch, authorized_update, reply_context
+):
+    monkeypatch.setattr(handlers.agent, "run_agent", lambda instr: ("Deal with #42 first.", []))
+    reply_context.args = ["what", "is", "urgent"]
+    await handlers.agent_command(authorized_update, reply_context)
+
+    markups = [
+        c.kwargs["reply_markup"]
+        for c in authorized_update.effective_chat.send_message.await_args_list
+        if c.kwargs.get("reply_markup")
+    ]
+    cbs = [b.callback_data for kb in markups for row in kb.inline_keyboard for b in row]
+    assert "e:view:42" in cbs  # the agent's #42 reference became a tap-to-open button
+
+
 @pytest.mark.asyncio
 async def test_agent_command_deletes_status_message(monkeypatch, authorized_update, reply_context):
     status = MagicMock()


### PR DESCRIPTION
Closes #93

## Summary
The agent's triage answers reference emails by `#id` but they weren't actionable. An informational agent reply now attaches **📖 #<id>** buttons (max 6, deduped, in order) for every email it mentions, reusing `cb_email_view` to open the detail view.

## Test plan
- [x] `_email_refs_keyboard` extracts/dedupes ids → `e:view:<id>`; None without ids
- [x] agent reply attaches the buttons
- [x] black + flake8 + bandit clean; pytest 316 passed
